### PR TITLE
fix: arredonda destaque da data selecionada

### DIFF
--- a/src/components/DateTimePickerModal.js
+++ b/src/components/DateTimePickerModal.js
@@ -491,6 +491,7 @@ const styles = StyleSheet.create({
     aspectRatio: 1,
     alignItems: 'center',
     justifyContent: 'center',
+    backgroundColor: colors.transparent,
   },
   dayCellDisabled: {
     opacity: 0.35,
@@ -498,12 +499,14 @@ const styles = StyleSheet.create({
   dayNumberCircle: {
     width: 34,
     height: 34,
-    borderRadius: 17,
+    borderRadius: 999,
     alignItems: 'center',
     justifyContent: 'center',
+    overflow: 'hidden',
   },
   dayNumberCircleSelected: {
     backgroundColor: colors.primary,
+    borderRadius: 999,
   },
   dayText: {
     color: colors.text,


### PR DESCRIPTION
## O que mudou

- Reforca o arredondamento do destaque da data selecionada no calendario proprio da Agenda.
- Mantem a celula do dia transparente e aplica o fundo somente no circulo interno selecionado.
- Adiciona `overflow: hidden` e `borderRadius` alto para evitar renderizacao com cantos quadrados.

## Validacao

- Parse Babel de `src/components/DateTimePickerModal.js`.
- `git diff --check`.

Refs #57