### PR TITLE
feat: exibe versao do app no login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beautyapp",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beautyapp",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "0BSD",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beautyapp",
   "license": "0BSD",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "index.js",
   "scripts": {
     "start": "npx expo start --clear --go",

--- a/src/screens/auth/LoginScreen.jsx
+++ b/src/screens/auth/LoginScreen.jsx
@@ -1,13 +1,16 @@
 ﻿import React, { useState, useEffect } from 'react';
-import { View, TextInput, StyleSheet, Alert, Image, ActivityIndicator, Modal } from 'react-native';
+import { View, Text, TextInput, StyleSheet, Alert, Image, ActivityIndicator, Modal } from 'react-native';
 import validator from 'validator';
 import { useNavigation } from '@react-navigation/native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import appPackage from '../../../package.json';
 import api from '../../services/api';
 import { setAuthToken } from '../../services/authStorage';
 import Button from '../../components/button';
 import Toggle from '../../components/toggle';
 import colors from '../../constants/colors';
+
+const APP_VERSION = appPackage.version || '0.0.0';
 
 const LoginScreen = () => {
   const [email, setEmail] = useState('');
@@ -137,6 +140,8 @@ const LoginScreen = () => {
         </View>
       </View>
 
+      <Text style={styles.versionText}>v{APP_VERSION}</Text>
+
       <Modal visible={isLoading} transparent animationType="fade" statusBarTranslucent>
         <View style={styles.loadingOverlay}>
           <View style={styles.loadingBox}>
@@ -185,6 +190,14 @@ const styles = StyleSheet.create({
     height: 250,
     alignSelf: 'center',
     marginBottom: -50,
+  },
+  versionText: {
+    position: 'absolute',
+    bottom: 18,
+    alignSelf: 'center',
+    color: colors.darkGray,
+    fontSize: 12,
+    fontWeight: '600',
   },
 });
 


### PR DESCRIPTION
## O que mudou

- Exibe a versão visível do app no rodapé da tela de login.
- Atualiza a versão visível de `1.1.0` para `1.1.1` em `package.json` e `package-lock.json`.
- Usa a versão do `package.json` para facilitar validar se um OTA chegou ao aparelho.

## Nota de OTA

`app.json` não foi alterado nesta tarefa porque o app usa `runtimeVersion` com política `appVersion`. Alterar `expo.version` em uma entrega apenas JS poderia mudar o runtime esperado e impedir o OTA de chegar ao binário instalado.

## Validação

- Parse Babel de `src/screens/auth/LoginScreen.jsx`.
- JSON parse de `package.json` e `app.json`.
- `git diff --check`.

Refs #71