### PR TITLE
release: promove versao visivel no login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beautyapp",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beautyapp",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "0BSD",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beautyapp",
   "license": "0BSD",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "index.js",
   "scripts": {
     "start": "npx expo start --clear --go",

--- a/src/screens/auth/LoginScreen.jsx
+++ b/src/screens/auth/LoginScreen.jsx
@@ -1,13 +1,16 @@
 ﻿import React, { useState, useEffect } from 'react';
-import { View, TextInput, StyleSheet, Alert, Image, ActivityIndicator, Modal } from 'react-native';
+import { View, Text, TextInput, StyleSheet, Alert, Image, ActivityIndicator, Modal } from 'react-native';
 import validator from 'validator';
 import { useNavigation } from '@react-navigation/native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import appPackage from '../../../package.json';
 import api from '../../services/api';
 import { setAuthToken } from '../../services/authStorage';
 import Button from '../../components/button';
 import Toggle from '../../components/toggle';
 import colors from '../../constants/colors';
+
+const APP_VERSION = appPackage.version || '0.0.0';
 
 const LoginScreen = () => {
   const [email, setEmail] = useState('');
@@ -137,6 +140,8 @@ const LoginScreen = () => {
         </View>
       </View>
 
+      <Text style={styles.versionText}>v{APP_VERSION}</Text>
+
       <Modal visible={isLoading} transparent animationType="fade" statusBarTranslucent>
         <View style={styles.loadingOverlay}>
           <View style={styles.loadingBox}>
@@ -185,6 +190,14 @@ const styles = StyleSheet.create({
     height: 250,
     alignSelf: 'center',
     marginBottom: -50,
+  },
+  versionText: {
+    position: 'absolute',
+    bottom: 18,
+    alignSelf: 'center',
+    color: colors.darkGray,
+    fontSize: 12,
+    fontWeight: '600',
   },
 });
 


### PR DESCRIPTION
## O que mudou

Promove para `master` a exibição da versão do app na tela de login.

Inclui:
- versão visível `1.1.1` em `package.json`/lock;
- rodapé `v1.1.1` no Login;
- `app.json` preservado para não alterar runtime OTA nesta entrega JS.

## Validação

- Parse Babel de `src/screens/auth/LoginScreen.jsx` em `develop`.
- JSON parse de `package.json` e `app.json`.

Refs #71