### PR TITLE
fix: abre seletores da agenda no ios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beautyapp",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beautyapp",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "0BSD",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beautyapp",
   "license": "0BSD",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "index.js",
   "scripts": {
     "start": "npx expo start --clear --go",

--- a/src/components/DateTimePickerModal.js
+++ b/src/components/DateTimePickerModal.js
@@ -93,6 +93,7 @@ const DateTimePickerModal = ({
   maximumDate,
   minuteInterval,
   useAppPicker = false,
+  inlineSheet = false,
   onCancel,
   onConfirm,
 }) => {
@@ -281,6 +282,82 @@ const DateTimePickerModal = ({
     </View>
   );
 
+  const sheetContent = (
+    <>
+      <TouchableOpacity
+        style={styles.backdropPressable}
+        activeOpacity={1}
+        onPress={onCancel}
+        accessibilityRole="button"
+        accessibilityLabel="Fechar seletor"
+      />
+
+      <View
+        style={[
+          styles.sheet,
+          inlineSheet && styles.inlineSheet,
+          { paddingBottom: 18 + Math.max(insets.bottom, 6) },
+        ]}
+      >
+        <View style={styles.grabber} />
+
+        <View style={styles.header}>
+          <TouchableOpacity onPress={onCancel} hitSlop={10}>
+            <Text style={styles.cancelText}>{cancelText}</Text>
+          </TouchableOpacity>
+
+          <Text style={styles.title}>{title}</Text>
+
+          <TouchableOpacity
+            onPress={() => onConfirm?.(draftValue)}
+            hitSlop={10}
+            accessibilityRole="button"
+            accessibilityLabel={confirmText}
+          >
+            <Text style={styles.confirmText}>{confirmText}</Text>
+          </TouchableOpacity>
+        </View>
+
+        <View
+          style={[
+            styles.pickerCard,
+            (resolvedIosDisplay === 'spinner' || useAppPicker) && styles.spinnerPickerCard,
+          ]}
+        >
+          {useAppPicker ? (
+            mode === 'time' ? renderAppTimePicker() : renderAppDatePicker()
+          ) : (
+            <DateTimePicker
+              value={draftValue}
+              mode={mode}
+              display={resolvedIosDisplay}
+              minimumDate={minimumDate}
+              maximumDate={maximumDate}
+              minuteInterval={minuteInterval}
+              onChange={(_event, selectedDate) => {
+                if (selectedDate) {
+                  setDraftValue(selectedDate);
+                }
+              }}
+              style={[
+                styles.iosPicker,
+                resolvedIosDisplay === 'spinner' && styles.spinnerPicker,
+              ]}
+            />
+          )}
+        </View>
+      </View>
+    </>
+  );
+
+  if (inlineSheet) {
+    return (
+      <View style={styles.inlineOverlay}>
+        {sheetContent}
+      </View>
+    );
+  }
+
   return (
     <Modal
       visible={visible}
@@ -290,63 +367,7 @@ const DateTimePickerModal = ({
       onRequestClose={onCancel}
     >
       <View style={styles.overlay}>
-        <TouchableOpacity
-          style={styles.backdropPressable}
-          activeOpacity={1}
-          onPress={onCancel}
-          accessibilityRole="button"
-          accessibilityLabel="Fechar seletor"
-        />
-
-        <View style={[styles.sheet, { paddingBottom: 18 + Math.max(insets.bottom, 6) }]}>
-          <View style={styles.grabber} />
-
-          <View style={styles.header}>
-            <TouchableOpacity onPress={onCancel} hitSlop={10}>
-              <Text style={styles.cancelText}>{cancelText}</Text>
-            </TouchableOpacity>
-
-            <Text style={styles.title}>{title}</Text>
-
-            <TouchableOpacity
-              onPress={() => onConfirm?.(draftValue)}
-              hitSlop={10}
-              accessibilityRole="button"
-              accessibilityLabel={confirmText}
-            >
-              <Text style={styles.confirmText}>{confirmText}</Text>
-            </TouchableOpacity>
-          </View>
-
-          <View
-            style={[
-              styles.pickerCard,
-              (resolvedIosDisplay === 'spinner' || useAppPicker) && styles.spinnerPickerCard,
-            ]}
-          >
-            {useAppPicker ? (
-              mode === 'time' ? renderAppTimePicker() : renderAppDatePicker()
-            ) : (
-              <DateTimePicker
-                value={draftValue}
-                mode={mode}
-                display={resolvedIosDisplay}
-                minimumDate={minimumDate}
-                maximumDate={maximumDate}
-                minuteInterval={minuteInterval}
-                onChange={(_event, selectedDate) => {
-                  if (selectedDate) {
-                    setDraftValue(selectedDate);
-                  }
-                }}
-                style={[
-                  styles.iosPicker,
-                  resolvedIosDisplay === 'spinner' && styles.spinnerPicker,
-                ]}
-              />
-            )}
-          </View>
-        </View>
+        {sheetContent}
       </View>
     </Modal>
   );
@@ -357,6 +378,13 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: colors.overlay,
     justifyContent: 'flex-end',
+  },
+  inlineOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: colors.overlay,
+    justifyContent: 'flex-end',
+    zIndex: 20,
+    elevation: 20,
   },
   backdropPressable: {
     ...StyleSheet.absoluteFillObject,
@@ -373,6 +401,9 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.16,
     shadowRadius: 12,
     elevation: 10,
+  },
+  inlineSheet: {
+    maxHeight: '94%',
   },
   grabber: {
     alignSelf: 'center',

--- a/src/screens/calendar/AgendaScreen.jsx
+++ b/src/screens/calendar/AgendaScreen.jsx
@@ -1160,20 +1160,21 @@ const AgendaScreen = () => {
               </View>
             </ScrollView>
           </View>
+
+          <DateTimePickerModal
+            visible={showStartPicker}
+            value={form.startAt}
+            mode={startPickerMode}
+            title={startPickerMode === 'date' ? 'Data do agendamento' : 'Horário do agendamento'}
+            iosDisplay={startPickerMode === 'date' ? 'inline' : 'spinner'}
+            minuteInterval={5}
+            useAppPicker
+            inlineSheet
+            onCancel={handleStartPickerCancel}
+            onConfirm={handleStartPickerConfirm}
+          />
         </View>
       </Modal>
-
-      <DateTimePickerModal
-        visible={showStartPicker}
-        value={form.startAt}
-        mode={startPickerMode}
-        title={startPickerMode === 'date' ? 'Data do agendamento' : 'Horário do agendamento'}
-        iosDisplay={startPickerMode === 'date' ? 'inline' : 'spinner'}
-        minuteInterval={5}
-        useAppPicker
-        onCancel={handleStartPickerCancel}
-        onConfirm={handleStartPickerConfirm}
-      />
 
       <FeedbackModal
         visible={feedback.visible}
@@ -1430,6 +1431,7 @@ const styles = StyleSheet.create({
   modalOverlay: {
     flex: 1,
     backgroundColor: colors.white,
+    position: 'relative',
   },
   modalContent: {
     flex: 1,


### PR DESCRIPTION
## O que mudou
- Ajusta o seletor proprio de data/hora para poder renderizar como bottom sheet inline, sem abrir outro Modal nativo.
- Usa esse modo inline dentro do modal de novo/editar agendamento da Agenda, evitando o empilhamento de Modal no iOS.
- Mantem o seletor do dia da agenda e os usos em Clientes no comportamento anterior.
- Incrementa a versao visivel do app para 1.1.2 em package.json/package-lock.json para validacao via OTA.

## Causa
No iOS, o seletor de data/hora do agendamento tentava abrir um segundo Modal nativo por cima do Modal de criacao/edicao. Isso podia falhar silenciosamente: o toque acontecia, mas nada era apresentado.

## Validacoes
- Parse/transpilacao Babel de src/components/DateTimePickerModal.js e src/screens/calendar/AgendaScreen.jsx.
- Parse JSON de package.json, package-lock.json e app.json.
- git diff --check.

Refs #57