### PR TITLE
fix: simplifica nascimento de cliente

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beautyapp",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beautyapp",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "0BSD",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beautyapp",
   "license": "0BSD",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "main": "index.js",
   "scripts": {
     "start": "npx expo start --clear --go",

--- a/src/screens/clients/cliente.jsx
+++ b/src/screens/clients/cliente.jsx
@@ -1,19 +1,46 @@
 import React, { useState, useEffect } from 'react';
-import { View, Text, FlatList, StyleSheet, ActivityIndicator, Alert, RefreshControl, TouchableOpacity, Modal, ScrollView } from 'react-native';
+import {
+  View,
+  Text,
+  FlatList,
+  StyleSheet,
+  ActivityIndicator,
+  Alert,
+  RefreshControl,
+  TouchableOpacity,
+  Modal,
+  ScrollView,
+} from 'react-native';
 import { TextInput } from 'react-native-paper';
 import { useNavigation } from '@react-navigation/native';
+import { Ionicons } from '@expo/vector-icons';
 import { getClients, removeClientLocally } from '../../services/private/listClient';
-import DateTimePickerModal from '../../components/DateTimePickerModal';
 import FeedbackModal from '../../components/FeedbackModal';
 import HeaderAddButton from '../../components/HeaderAddButton';
 import SearchInput from '../../components/SearchInput';
 import colors from '../../constants/colors';
-import { Ionicons } from '@expo/vector-icons';
 import api from '../../services/api';
 import { isSessionExpiredError } from '../../services/sessionManager';
+import formatPhoneNumber from '../../utils/formatNumber';
 import { validateFormData } from '../../utils/validations';
-import { formatDate } from '../../utils/formatBirthday';
+import { formatBirthDay, formatDate, formatDateForInput } from '../../utils/formatBirthday';
 import useFeedbackModal from '../../hooks/useFeedbackModal';
+
+const getInitialEditedClient = () => ({
+  name: '',
+  lastName: '',
+  phone: '',
+  email: '',
+  birthDate: '',
+  address: '',
+});
+
+const hasOptionalClientInfo = (client) => Boolean(
+  client?.lastName
+  || client?.email
+  || client?.birthDate
+  || client?.address
+);
 
 const ClientScreen = () => {
   const navigation = useNavigation();
@@ -24,47 +51,42 @@ const ClientScreen = () => {
   const [selectedClient, setSelectedClient] = useState(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [filteredClients, setFilteredClients] = useState([]);
+  const [editedClient, setEditedClient] = useState(getInitialEditedClient);
+  const [showOptionalFields, setShowOptionalFields] = useState(false);
   const { feedback, showFeedback, hideFeedback } = useFeedbackModal();
-  const [editedClient, setEditedClient] = useState({
-    name: '',
-    lastName: '',
-    phone: '',
-    email: '',
-    birthDate: new Date(),
-    address: ''
-  });
-  const [showDatePicker, setShowDatePicker] = useState(false);
 
   useEffect(() => {
     fetchClients();
   }, []);
+
   useEffect(() => {
     if (searchQuery.trim() === '') {
       setFilteredClients(clients);
-    } else {
-      const query = searchQuery.toLowerCase();
-      const filtered = clients.filter(client =>
-      (client.name?.toLowerCase().includes(query) ||
-        client.lastName?.toLowerCase().includes(query) ||
-        client.phone?.includes(query) ||
-        client.email?.toLowerCase().includes(query))
-      );
-      setFilteredClients(filtered);
+      return;
     }
 
+    const query = searchQuery.toLowerCase();
+    const filtered = clients.filter((client) => (
+      client.name?.toLowerCase().includes(query)
+      || client.lastName?.toLowerCase().includes(query)
+      || client.phone?.includes(query)
+      || client.email?.toLowerCase().includes(query)
+    ));
+
+    setFilteredClients(filtered);
   }, [searchQuery, clients]);
 
   const fetchClients = async () => {
     try {
       setRefreshing(true);
-      console.log("🔄 Buscando clientes da API...");
+      console.log('Buscando clientes da API...');
 
       const clientList = await getClients();
-      console.log("✅ Clientes recebidos");
+      console.log('Clientes recebidos');
 
       setClients(clientList);
     } catch (error) {
-      console.error("❌ Erro ao buscar clientes:", error);
+      console.error('Erro ao buscar clientes:', error);
       if (!isSessionExpiredError(error)) {
         showFeedback({
           type: 'error',
@@ -78,6 +100,13 @@ const ClientScreen = () => {
     }
   };
 
+  const closeEditModal = () => {
+    setModalVisible(false);
+    setShowOptionalFields(false);
+    setSelectedClient(null);
+    setEditedClient(getInitialEditedClient());
+  };
+
   const handleEditClient = (client) => {
     setSelectedClient(client);
     setEditedClient({
@@ -85,35 +114,55 @@ const ClientScreen = () => {
       lastName: client.lastName || '',
       phone: client.phone || '',
       email: client.email || '',
-      birthDate: client.birthDate ? new Date(client.birthDate) : new Date(),
-      address: client.address || ''
+      birthDate: formatDateForInput(client.birthDate),
+      address: client.address || '',
     });
+    setShowOptionalFields(hasOptionalClientInfo(client));
     setModalVisible(true);
   };
 
+  const handlePhoneChange = (text) => {
+    setEditedClient((previousClient) => ({
+      ...previousClient,
+      phone: formatPhoneNumber(text),
+    }));
+  };
+
+  const handleBirthDateChange = (text) => {
+    setEditedClient((previousClient) => ({
+      ...previousClient,
+      birthDate: formatBirthDay(text),
+    }));
+  };
+
+  const buildClientPayload = () => ({
+    name: editedClient.name.trim(),
+    lastName: editedClient.lastName.trim(),
+    phone: editedClient.phone.trim() || null,
+    email: editedClient.email.trim() || null,
+    birthDate: formatDate(editedClient.birthDate),
+    address: editedClient.address.trim(),
+  });
+
   const handleSaveChanges = async () => {
     try {
-
-      const clientToUpdate = {
-        ...editedClient,
-        email: editedClient.email.trim() || null,
-        birthDate: formatDate(editedClient.birthDate)
-      };
+      const clientToUpdate = buildClientPayload();
 
       if (!validateFormData(clientToUpdate)) {
         return;
       }
 
-      console.log("🔄 Atualizando cliente na API...");
+      console.log('Atualizando cliente na API...');
       const response = await api.patch(`/clients/update/${selectedClient.id}`, clientToUpdate);
 
       if (response.status === 200) {
-        const updatedClients = clients.map(client =>
-          client.id === selectedClient.id ? { ...client, ...editedClient } : client
-        );
+        const updatedClient = response.data;
+        const updatedClients = clients.map((client) => (
+          client.id === selectedClient.id ? { ...client, ...updatedClient } : client
+        ));
 
         setClients(updatedClients);
-        setModalVisible(false);
+        closeEditModal();
         showFeedback({
           type: 'success',
           title: 'Sucesso',
@@ -127,7 +176,7 @@ const ClientScreen = () => {
         });
       }
     } catch (error) {
-      console.error("❌ Erro ao atualizar cliente:", error.response?.data || error.message);
+      console.error('Erro ao atualizar cliente:', error.response?.data || error.message);
       showFeedback({
         type: 'error',
         title: 'Erro',
@@ -138,7 +187,7 @@ const ClientScreen = () => {
 
   const handleDeleteClient = (client) => {
     Alert.alert(
-      'Confirmar Exclusão',
+      'Confirmar exclusão',
       `Deseja realmente excluir o cliente ${client.name} ${client.lastName || ''}?`,
       [
         { text: 'Cancelar', style: 'cancel' },
@@ -151,7 +200,7 @@ const ClientScreen = () => {
               await removeClientLocally(client.id);
               fetchClients();
 
-              const updatedClients = clients.filter(c => c.id !== client.id);
+              const updatedClients = clients.filter((currentClient) => currentClient.id !== client.id);
               setClients(updatedClients);
 
               showFeedback({
@@ -160,31 +209,24 @@ const ClientScreen = () => {
                 message: 'Cliente excluído com sucesso!',
               });
             } catch (error) {
-              console.error("❌ Erro ao excluir cliente:", error);
+              console.error('Erro ao excluir cliente:', error);
               showFeedback({
                 type: 'error',
                 title: 'Erro',
                 message: 'Não foi possível excluir o cliente.',
               });
             }
-          }
-        }
-      ]
+          },
+        },
+      ],
     );
-  };
-
-  const handleDateConfirm = (selectedDate) => {
-    setShowDatePicker(false);
-    if (selectedDate) {
-      setEditedClient({ ...editedClient, birthDate: selectedDate });
-    }
   };
 
   const renderClientItem = ({ item }) => (
     <View style={styles.item}>
       <View style={styles.clientInfo}>
         <Text style={styles.title}>Nome: {item.name} {item.lastName}</Text>
-        <Text>Telefone: {item.phone}</Text>
+        <Text>Telefone: {item.phone || 'Não informado'}</Text>
         {item.email ? <Text>Email: {item.email}</Text> : null}
       </View>
       <TouchableOpacity
@@ -196,7 +238,9 @@ const ClientScreen = () => {
     </View>
   );
 
-  if (loading) return <ActivityIndicator style={{ flex: 1 }} size="large" color={colors.primary} />;
+  if (loading) {
+    return <ActivityIndicator style={{ flex: 1 }} size="large" color={colors.primary} />;
+  }
 
   return (
     <View style={styles.container}>
@@ -220,20 +264,19 @@ const ClientScreen = () => {
         <FlatList
           data={filteredClients}
           renderItem={renderClientItem}
-          keyExtractor={item => item.id.toString()}
+          keyExtractor={(item) => item.id.toString()}
           contentContainerStyle={styles.listContainer}
-          refreshControl={
+          refreshControl={(
             <RefreshControl refreshing={refreshing} onRefresh={fetchClients} />
-          }
+          )}
         />
       </View>
 
-      {/* MODAL DE EDIÇÃO DE CLIENTE */}
       <Modal
         animationType="slide"
-        transparent={true}
+        transparent
         visible={modalVisible}
-        onRequestClose={() => setModalVisible(false)}
+        onRequestClose={closeEditModal}
       >
         <View style={styles.modalContainer}>
           <View style={styles.modalContent}>
@@ -243,9 +286,10 @@ const ClientScreen = () => {
                 <TouchableOpacity
                   style={styles.deleteIconButton}
                   onPress={() => {
-                    setModalVisible(false);
+                    const clientToDelete = selectedClient;
+                    closeEditModal();
                     setTimeout(() => {
-                      handleDeleteClient(selectedClient);
+                      handleDeleteClient(clientToDelete);
                     }, 300);
                   }}
                 >
@@ -264,60 +308,71 @@ const ClientScreen = () => {
               <TextInput
                 style={styles.input}
                 mode="outlined"
-                label="Sobrenome"
-                value={editedClient.lastName}
-                onChangeText={(text) => setEditedClient({ ...editedClient, lastName: text })}
-              />
-
-              <TextInput
-                style={styles.input}
-                mode="outlined"
-                label="Telefone *"
+                label="Telefone"
                 value={editedClient.phone}
-                onChangeText={(text) => setEditedClient({ ...editedClient, phone: text })}
+                onChangeText={handlePhoneChange}
                 keyboardType="phone-pad"
               />
 
-              <TextInput
-                style={styles.input}
-                mode="outlined"
-                label="Email (opcional)"
-                value={editedClient.email}
-                onChangeText={(text) => setEditedClient({ ...editedClient, email: text })}
-                keyboardType="email-address"
-                autoCapitalize="none"
-              />
-
               <TouchableOpacity
-                activeOpacity={0.7}
-                onPress={() => setShowDatePicker(true)}
+                style={styles.optionalToggle}
+                activeOpacity={0.75}
+                onPress={() => setShowOptionalFields((currentValue) => !currentValue)}
               >
-                <TextInput
-                  style={styles.input}
-                  mode="outlined"
-                  label="Data de Nascimento *"
-                  editable={false}
-                  value={formatDate(editedClient.birthDate)}
-                  right={<TextInput.Icon icon="calendar" onPress={() => setShowDatePicker(true)} />}
-                  pointerEvents="none"
-                />
+                <Text style={styles.optionalToggleText}>
+                  {showOptionalFields ? 'Ocultar opções' : 'Mais opções'}
+                </Text>
+                <Text style={styles.optionalToggleIcon}>{showOptionalFields ? 'v' : '>'}</Text>
               </TouchableOpacity>
 
-              <TextInput
-                style={[styles.input, styles.addressInput]}
-                mode="outlined"
-                label="Endereço"
-                value={editedClient.address}
-                onChangeText={(text) => setEditedClient({ ...editedClient, address: text })}
-                multiline
-              />
+              {showOptionalFields && (
+                <View style={styles.optionalFields}>
+                  <TextInput
+                    style={styles.input}
+                    mode="outlined"
+                    label="Sobrenome"
+                    value={editedClient.lastName}
+                    onChangeText={(text) => setEditedClient({ ...editedClient, lastName: text })}
+                  />
 
-              <Text style={styles.helperText}>* Campos obrigatórios</Text>
+                  <TextInput
+                    style={styles.input}
+                    mode="outlined"
+                    label="Email (opcional)"
+                    value={editedClient.email}
+                    onChangeText={(text) => setEditedClient({ ...editedClient, email: text })}
+                    keyboardType="email-address"
+                    autoCapitalize="none"
+                  />
+
+                  <TextInput
+                    style={styles.input}
+                    mode="outlined"
+                    label="Nascimento (opcional)"
+                    placeholder="09/08/1999"
+                    value={editedClient.birthDate}
+                    onChangeText={handleBirthDateChange}
+                    keyboardType="number-pad"
+                    maxLength={10}
+                  />
+
+                  <TextInput
+                    style={[styles.input, styles.addressInput]}
+                    mode="outlined"
+                    label="Endereço"
+                    value={editedClient.address}
+                    onChangeText={(text) => setEditedClient({ ...editedClient, address: text })}
+                    multiline
+                  />
+                </View>
+              )}
+
+              <Text style={styles.helperText}>* Apenas nome é obrigatório.</Text>
 
               <View style={styles.modalButtons}>
                 <TouchableOpacity
                   style={[styles.modalButton, styles.cancelButton]}
-                  onPress={() => setModalVisible(false)}
+                  onPress={closeEditModal}
                 >
                   <Text style={styles.buttonText}>Cancelar</Text>
                 </TouchableOpacity>
@@ -333,16 +388,6 @@ const ClientScreen = () => {
           </View>
         </View>
       </Modal>
-
-      <DateTimePickerModal
-        visible={showDatePicker}
-        value={editedClient.birthDate || new Date()}
-        mode="date"
-        title="Data de nascimento"
-        iosDisplay="spinner"
-        onCancel={() => setShowDatePicker(false)}
-        onConfirm={handleDateConfirm}
-      />
 
       <FeedbackModal
         visible={feedback.visible}
@@ -394,10 +439,10 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     flexDirection: 'row',
     justifyContent: 'space-between',
-    alignItems: 'center'
+    alignItems: 'center',
   },
   clientInfo: {
-    flex: 1
+    flex: 1,
   },
   title: {
     fontSize: 16,
@@ -436,6 +481,32 @@ const styles = StyleSheet.create({
     marginBottom: 5,
     fontSize: 16,
   },
+  optionalToggle: {
+    minHeight: 44,
+    marginTop: 6,
+    marginBottom: 8,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.white,
+    paddingHorizontal: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  optionalToggleText: {
+    color: colors.primary,
+    fontSize: 14,
+    fontWeight: '700',
+  },
+  optionalToggleIcon: {
+    color: colors.primary,
+    fontSize: 18,
+    fontWeight: '800',
+  },
+  optionalFields: {
+    marginBottom: 2,
+  },
   addressInput: {
     height: 80,
     textAlignVertical: 'top',
@@ -472,7 +543,6 @@ const styles = StyleSheet.create({
     color: colors.white,
     fontWeight: 'bold',
   },
-
 });
 
 export default ClientScreen;

--- a/src/screens/clients/registerCustomer.jsx
+++ b/src/screens/clients/registerCustomer.jsx
@@ -3,34 +3,32 @@ import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-nati
 import { TextInput } from 'react-native-paper';
 import { useNavigation } from '@react-navigation/native';
 import Button from '../../components/button';
-import DateTimePickerModal from '../../components/DateTimePickerModal';
 import FeedbackModal from '../../components/FeedbackModal';
 import api from '../../services/api';
 import formatPhoneNumber from '../../utils/formatNumber';
 import { validateFormData } from '../../utils/validations';
-import { formatDate } from '../../utils/formatBirthday';
+import { formatBirthDay, formatDate } from '../../utils/formatBirthday';
 import colors from '../../constants/colors';
 import useFeedbackModal from '../../hooks/useFeedbackModal';
 
 export default function RegisterClientScreeen() {
   const navigation = useNavigation();
   const { feedback, showFeedback, hideFeedback } = useFeedbackModal();
+  const [showOptionalFields, setShowOptionalFields] = useState(false);
   const [formData, setFormData] = useState({
     name: '',
     lastName: '',
     email: '',
     phone: '',
-    birthDate: new Date(1990, 5, 1),
-    address: ''
+    birthDate: '',
+    address: '',
   });
-  const [showDatePicker, setShowDatePicker] = useState(false);
-
 
   const handleInputChange = (field, value) => {
-    setFormData({
-      ...formData,
-      [field]: value
-    });
+    setFormData((previousData) => ({
+      ...previousData,
+      [field]: value,
+    }));
   };
 
   const handlePhoneChange = (text) => {
@@ -38,27 +36,29 @@ export default function RegisterClientScreeen() {
     handleInputChange('phone', formattedPhone);
   };
 
-  const handleDateConfirm = (selectedDate) => {
-    setShowDatePicker(false);
-    if (selectedDate) {
-      setFormData({ ...formData, birthDate: selectedDate });
-    }
+  const handleBirthDateChange = (text) => {
+    handleInputChange('birthDate', formatBirthDay(text));
   };
 
+  const buildClientPayload = () => ({
+    name: formData.name.trim(),
+    lastName: formData.lastName.trim(),
+    email: formData.email.trim() || null,
+    phone: formData.phone.trim() || null,
+    birthDate: formatDate(formData.birthDate),
+    address: formData.address.trim(),
+  });
+
   const handleRegister = async () => {
-    const clientToRegister = {
-      ...formData,
-      email: formData.email.trim() || null,
-      birthDate: formatDate(formData.birthDate)
-    };
+    const clientToRegister = buildClientPayload();
+
     if (!validateFormData(clientToRegister)) {
       return;
     }
+
     console.log('Dados do cliente a serem enviados:', clientToRegister);
     try {
-      const response = await api.post('/clients/register',
-        clientToRegister
-      );
+      const response = await api.post('/clients/register', clientToRegister);
 
       if (response.data.success) {
         showFeedback({
@@ -110,25 +110,7 @@ export default function RegisterClientScreeen() {
           <TextInput
             style={styles.input}
             mode="outlined"
-            label="Sobrenome"
-            value={formData.lastName}
-            onChangeText={(value) => handleInputChange('lastName', value)}
-          />
-
-          <TextInput
-            style={styles.input}
-            mode="outlined"
-            label="Email (opcional)"
-            keyboardType="email-address"
-            textContentType="emailAddress"
-            value={formData.email}
-            onChangeText={(value) => handleInputChange('email', value)}
-          />
-
-          <TextInput
-            style={styles.input}
-            mode="outlined"
-            label="Telefone *"
+            label="Telefone"
             placeholder="+55"
             keyboardType="phone-pad"
             value={formData.phone}
@@ -136,29 +118,59 @@ export default function RegisterClientScreeen() {
           />
 
           <TouchableOpacity
-            activeOpacity={0.7}
-            onPress={() => setShowDatePicker(true)}
+            style={styles.optionalToggle}
+            activeOpacity={0.75}
+            onPress={() => setShowOptionalFields((currentValue) => !currentValue)}
           >
-            <TextInput
-              style={styles.input}
-              mode="outlined"
-              label="Data de Nascimento *"
-              editable={false}
-              value={formData.birthDate instanceof Date ? formatDate(formData.birthDate) : ""}
-              right={<TextInput.Icon icon="calendar" onPress={() => setShowDatePicker(true)} />}
-              pointerEvents="none"
-            />
+            <Text style={styles.optionalToggleText}>
+              {showOptionalFields ? 'Ocultar opções' : 'Mais opções'}
+            </Text>
+            <Text style={styles.optionalToggleIcon}>{showOptionalFields ? 'v' : '>'}</Text>
           </TouchableOpacity>
 
-          <TextInput
-            style={styles.input}
-            mode="outlined"
-            label="Endereço"
-            value={formData.address}
-            onChangeText={(value) => handleInputChange('address', value)}
-          />
+          {showOptionalFields && (
+            <View style={styles.optionalFields}>
+              <TextInput
+                style={styles.input}
+                mode="outlined"
+                label="Sobrenome"
+                value={formData.lastName}
+                onChangeText={(value) => handleInputChange('lastName', value)}
+              />
 
-          <Text style={styles.helperText}>* Campos obrigatórios</Text>
+              <TextInput
+                style={styles.input}
+                mode="outlined"
+                label="Email (opcional)"
+                keyboardType="email-address"
+                textContentType="emailAddress"
+                autoCapitalize="none"
+                value={formData.email}
+                onChangeText={(value) => handleInputChange('email', value)}
+              />
+
+              <TextInput
+                style={styles.input}
+                mode="outlined"
+                label="Nascimento (opcional)"
+                placeholder="09/08/1999"
+                keyboardType="number-pad"
+                maxLength={10}
+                value={formData.birthDate}
+                onChangeText={handleBirthDateChange}
+              />
+
+              <TextInput
+                style={styles.input}
+                mode="outlined"
+                label="Endereço"
+                value={formData.address}
+                onChangeText={(value) => handleInputChange('address', value)}
+              />
+            </View>
+          )}
+
+          <Text style={styles.helperText}>* Apenas nome é obrigatório.</Text>
 
           <Button
             title="Cadastrar"
@@ -170,20 +182,6 @@ export default function RegisterClientScreeen() {
           />
         </View>
       </ScrollView>
-
-      <DateTimePickerModal
-        visible={showDatePicker}
-        value={
-          formData.birthDate instanceof Date && !isNaN(formData.birthDate.getTime())
-            ? formData.birthDate
-            : new Date()
-        }
-        mode="date"
-        title="Data de nascimento"
-        iosDisplay="spinner"
-        onCancel={() => setShowDatePicker(false)}
-        onConfirm={handleDateConfirm}
-      />
 
       <FeedbackModal
         visible={feedback.visible}
@@ -217,6 +215,32 @@ const styles = StyleSheet.create({
     height: 50,
     marginBottom: 5,
     fontSize: 16,
+  },
+  optionalToggle: {
+    minHeight: 44,
+    marginTop: 6,
+    marginBottom: 8,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.white,
+    paddingHorizontal: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  optionalToggleText: {
+    color: colors.primary,
+    fontSize: 14,
+    fontWeight: '700',
+  },
+  optionalToggleIcon: {
+    color: colors.primary,
+    fontSize: 18,
+    fontWeight: '800',
+  },
+  optionalFields: {
+    marginBottom: 2,
   },
   helperText: {
     color: colors.darkGray,

--- a/src/utils/formatBirthday.js
+++ b/src/utils/formatBirthday.js
@@ -1,21 +1,61 @@
 import { format } from 'date-fns';
+
 export function formatBirthDay(value) {
   if (!value) return '';
 
-  // Remove all non-numeric characters
-  const numbers = value.replace(/\D/g, '');
+  const numbers = String(value).replace(/\D/g, '').slice(0, 8);
 
-  // Format as yyyy-mm-dd
-  if (numbers.length <= 4) {
+  if (numbers.length <= 2) {
     return numbers;
-  } else if (numbers.length <= 6) {
-    return `${numbers.slice(0, 4)}-${numbers.slice(4)}`;
-  } else {
-    return `${numbers.slice(0, 4)}-${numbers.slice(4, 6)}-${numbers.slice(6, 8)}`;
   }
+
+  if (numbers.length <= 4) {
+    return `${numbers.slice(0, 2)}/${numbers.slice(2)}`;
+  }
+
+  return `${numbers.slice(0, 2)}/${numbers.slice(2, 4)}/${numbers.slice(4)}`;
+}
+
+export function formatDateForInput(value) {
+  if (!value) return '';
+
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return format(value, 'dd/MM/yyyy');
+  }
+
+  const dateString = String(value);
+  const isoDate = dateString.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (isoDate) {
+    return `${isoDate[3]}/${isoDate[2]}/${isoDate[1]}`;
+  }
+
+  return formatBirthDay(dateString);
 }
 
 export function formatDate(value) {
-  const formattedBirthdate = format(new Date(value), 'yyyy-MM-dd');
-  return formattedBirthdate;
+  if (!value) return null;
+
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return format(value, 'yyyy-MM-dd');
+  }
+
+  const dateString = String(value).trim();
+  if (!dateString) return null;
+
+  const isoDate = dateString.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (isoDate) {
+    return `${isoDate[1]}-${isoDate[2]}-${isoDate[3]}`;
+  }
+
+  const numbers = dateString.replace(/\D/g, '');
+  if (!numbers) return null;
+
+  if (numbers.length !== 8) {
+    return 'invalid-date';
+  }
+
+  const day = numbers.slice(0, 2);
+  const month = numbers.slice(2, 4);
+  const year = numbers.slice(4, 8);
+  return `${year}-${month}-${day}`;
 }

--- a/src/utils/formatNumber.js
+++ b/src/utils/formatNumber.js
@@ -1,17 +1,20 @@
 export default function formatPhoneNumber(text) {
   let cleaned = text.replace(/\D/g, '').replace(/^55/, '');
 
-  let formatted = '+55 ';
-  if (cleaned.length > 0) {
-    if (cleaned.length <= 2) {
-      formatted += `(${cleaned}`;
-    } else if (cleaned.length <= 7) {
-      formatted += `(${cleaned.substring(0, 2)}) ${cleaned.substring(2)}`;
-    } else if (cleaned.length <= 11) {
-      formatted += `(${cleaned.substring(0, 2)}) ${cleaned.substring(2, 7)}-${cleaned.substring(7)}`;
-    } else {
-      formatted += `(${cleaned.substring(0, 2)}) ${cleaned.substring(2, 7)}-${cleaned.substring(7, 11)}`;
-    }
+  if (!cleaned) {
+    return '';
   }
+
+  let formatted = '+55 ';
+  if (cleaned.length <= 2) {
+    formatted += `(${cleaned}`;
+  } else if (cleaned.length <= 7) {
+    formatted += `(${cleaned.substring(0, 2)}) ${cleaned.substring(2)}`;
+  } else if (cleaned.length <= 11) {
+    formatted += `(${cleaned.substring(0, 2)}) ${cleaned.substring(2, 7)}-${cleaned.substring(7)}`;
+  } else {
+    formatted += `(${cleaned.substring(0, 2)}) ${cleaned.substring(2, 7)}-${cleaned.substring(7, 11)}`;
+  }
+
   return formatted;
 };

--- a/src/utils/validations.js
+++ b/src/utils/validations.js
@@ -2,21 +2,29 @@ import validator from 'validator';
 import { Alert } from 'react-native';
 
 export const validateFormData = (formData) => {
+  const name = typeof formData.name === 'string' ? formData.name.trim() : formData.name;
   const email = typeof formData.email === 'string' ? formData.email.trim() : formData.email;
+  const birthDate = typeof formData.birthDate === 'string' ? formData.birthDate.trim() : formData.birthDate;
+  const hasBirthDate = typeof birthDate === 'string' && birthDate.length > 0;
 
   const validations = [
-    { condition: !formData.name, message: "É necessário fornecer o nome para finalizar o registro." },
-    { condition: !formData.phone, message: "É necessário fornecer o número de telefone para finalizar o registro." },
-    { condition: !formData.birthDate, message: "É necessário fornecer a data de nascimento para finalizar o registro." },
-    { condition: Boolean(email) && !validator.isEmail(email), message: "E-mail inválido." },
-    { condition: !validator.isDate(formData.birthDate, { format: 'YYYY-MM-DD', strictMode: true }), message: "Data de nascimento inválida. Use o formato YYYY-MM-DD." },
-    { condition: new Date(formData.birthDate.split('/').reverse().join('-')) > new Date(), message: "Data de nascimento não pode ser no futuro." }
+    { condition: !name, message: 'É necessário fornecer o nome para finalizar o registro.' },
+    { condition: Boolean(email) && !validator.isEmail(email), message: 'E-mail inválido.' },
+    {
+      condition: hasBirthDate && !validator.isDate(birthDate, { format: 'YYYY-MM-DD', strictMode: true }),
+      message: 'Data de nascimento inválida. Use o formato DD/MM/AAAA.',
+    },
+    {
+      condition: hasBirthDate && new Date(`${birthDate}T00:00:00`) > new Date(),
+      message: 'Data de nascimento não pode ser no futuro.',
+    },
   ];
 
-  const error = validations.find(v => v.condition);
+  const error = validations.find((validation) => validation.condition);
   if (error) {
-    Alert.alert("Erro", error.message);
+    Alert.alert('Erro', error.message);
     return false;
   }
+
   return true;
-}
+};


### PR DESCRIPTION
## O que mudou
- Remove o date picker de nascimento no cadastro e edicao de cliente.
- Usa campo digitavel com mascara dd/mm/aaaa para nascimento opcional.
- Deixa apenas nome como obrigatorio no app; telefone fica visivel e recomendado, mas opcional.
- Move sobrenome, e-mail, nascimento e endereco para uma area recolhida em Mais opcoes.
- Ajusta formatacao/validacao mobile de nascimento e telefone vazio.
- Incrementa a versao visivel do app para 1.1.3.

## Por que
No app atual, a data de nascimento nao abria de forma confiavel e obrigava a usuaria a lidar com um seletor desnecessario para um dado opcional.

## Validacoes
- Parse/transpilacao Babel de registerCustomer.jsx, cliente.jsx e utilitarios alterados.
- Parse JSON de package.json, package-lock.json e app.json.
- git diff --check.

Refs #77
Depende do contrato da API em lBorD/api#23.