### PR TITLE
fix: ajusta modal de agendamento aos limites da tela

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beautyapp",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beautyapp",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "0BSD",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beautyapp",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beautyapp",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "0BSD",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beautyapp",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beautyapp",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "0BSD",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beautyapp",
   "license": "0BSD",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "main": "index.js",
   "scripts": {
     "start": "npx expo start --clear --go",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beautyapp",
   "license": "0BSD",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "main": "index.js",
   "scripts": {
     "start": "npx expo start --clear --go",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beautyapp",
   "license": "0BSD",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "main": "index.js",
   "scripts": {
     "start": "npx expo start --clear --go",

--- a/src/screens/calendar/AgendaScreen.jsx
+++ b/src/screens/calendar/AgendaScreen.jsx
@@ -1005,7 +1005,12 @@ const AgendaScreen = () => {
       {modalVisible && (
         <View style={styles.modalOverlay}>
           <View style={[styles.modalContent, { paddingTop: 14 + insets.top, paddingBottom: 14 + bottomInset }]}>
-            <ScrollView showsVerticalScrollIndicator={false}>
+            <ScrollView
+              style={styles.modalScroll}
+              contentContainerStyle={styles.modalScrollContent}
+              showsVerticalScrollIndicator={false}
+              keyboardShouldPersistTaps="handled"
+            >
               <Text style={styles.modalTitle}>{isEditing ? 'Editar agendamento' : 'Novo agendamento'}</Text>
 
               <Text style={styles.fieldLabel}>Cliente</Text>
@@ -1455,12 +1460,9 @@ const styles = StyleSheet.create({
     shadowRadius: 4,
   },
   modalOverlay: {
-    position: 'absolute',
-    top: -56,
-    left: -16,
-    right: -16,
-    bottom: 0,
+    ...StyleSheet.absoluteFillObject,
     backgroundColor: colors.white,
+    overflow: 'hidden',
     zIndex: 20,
     elevation: 20,
   },
@@ -1468,6 +1470,12 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: colors.white,
     paddingHorizontal: 14,
+  },
+  modalScroll: {
+    flex: 1,
+  },
+  modalScrollContent: {
+    flexGrow: 1,
   },
   modalTitle: {
     fontSize: 19,

--- a/src/screens/calendar/AgendaScreen.jsx
+++ b/src/screens/calendar/AgendaScreen.jsx
@@ -506,7 +506,16 @@ const AgendaScreen = () => {
 
   const onRefresh = async () => {
     setRefreshing(true);
-    await Promise.all([loadClientsAndServices(), loadAgenda({ isRefresh: true })]);
+    try {
+      await Promise.all([loadClientsAndServices(), loadAgenda({ isRefresh: true })]);
+    } catch (error) {
+      console.error('Erro ao atualizar agenda:', error.response?.data || error.message);
+      if (!isSessionExpiredError(error)) {
+        Alert.alert('Erro', 'Não foi possível atualizar os dados da agenda.');
+      }
+    } finally {
+      setRefreshing(false);
+    }
   };
 
   const openCreateModal = async () => {
@@ -579,6 +588,7 @@ const AgendaScreen = () => {
     setShowStartPicker(false);
     setStartPickerMode('date');
     setSubmitting(false);
+    hideFeedback();
     setClientSearch('');
     setServiceSearch('');
     setClientSearchLoading(false);
@@ -879,6 +889,55 @@ const AgendaScreen = () => {
     </View>
   );
 
+  const renderEmptyAgenda = () => (
+    <View style={styles.emptyState}>
+      <Ionicons name="calendar-clear-outline" size={64} color={colors.lightGray} />
+      <Text style={styles.emptyTitle}>Nenhum agendamento neste dia</Text>
+      <Text style={styles.emptySubtitle}>Crie seu primeiro agendamento em poucos toques.</Text>
+
+      {!canSchedule && (
+        <View style={styles.emptyActions}>
+          <TouchableOpacity
+            style={styles.emptyActionButton}
+            onPress={() => navigation.navigate('RegisterCustomer')}
+          >
+            <Text style={styles.emptyActionText}>Cadastrar Cliente</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.emptyActionButton}
+            onPress={() => navigation.navigate('RegisterService')}
+          >
+            <Text style={styles.emptyActionText}>Cadastrar Serviço</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+    </View>
+  );
+
+  const renderInlineFeedback = () => {
+    if (!feedback.visible) {
+      return null;
+    }
+
+    const feedbackColor = feedback.type === 'error' ? colors.secondary : colors.primary;
+    const feedbackIcon = feedback.type === 'error' ? 'alert-circle' : 'checkmark-circle';
+
+    return (
+      <View style={[styles.inlineFeedback, { borderLeftColor: feedbackColor }]}>
+        <View style={styles.inlineFeedbackHeader}>
+          <Ionicons name={feedbackIcon} size={18} color={feedbackColor} />
+          <Text style={styles.inlineFeedbackTitle}>{feedback.title || 'Atenção'}</Text>
+        </View>
+        {feedback.message ? <Text style={styles.inlineFeedbackMessage}>{feedback.message}</Text> : null}
+        <TouchableOpacity style={styles.inlineFeedbackButton} onPress={hideFeedback}>
+          <Text style={[styles.inlineFeedbackButtonText, { color: feedbackColor }]}>
+            {feedback.buttonText || 'OK'}
+          </Text>
+        </TouchableOpacity>
+      </View>
+    );
+  };
+
   if (loading) {
     return (
       <View style={styles.loadingContainer}>
@@ -926,38 +985,20 @@ const AgendaScreen = () => {
         </View>
       </View>
 
-      {appointments.length === 0 ? (
-        <View style={styles.emptyState}>
-          <Ionicons name="calendar-clear-outline" size={64} color={colors.lightGray} />
-          <Text style={styles.emptyTitle}>Nenhum agendamento neste dia</Text>
-          <Text style={styles.emptySubtitle}>Crie seu primeiro agendamento em poucos toques.</Text>
-
-          {!canSchedule && (
-            <View style={styles.emptyActions}>
-              <TouchableOpacity
-                style={styles.emptyActionButton}
-                onPress={() => navigation.navigate('RegisterCustomer')}
-              >
-                <Text style={styles.emptyActionText}>Cadastrar Cliente</Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={styles.emptyActionButton}
-                onPress={() => navigation.navigate('RegisterService')}
-              >
-                <Text style={styles.emptyActionText}>Cadastrar Serviço</Text>
-              </TouchableOpacity>
-            </View>
-          )}
-        </View>
-      ) : (
-        <FlatList
-          data={appointments}
-          keyExtractor={(item) => String(item.id)}
-          renderItem={renderAppointmentItem}
-          contentContainerStyle={[styles.listContainer, { paddingBottom: 96 + bottomInset }]}
-          refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
-        />
-      )}
+      <FlatList
+        style={styles.list}
+        data={appointments}
+        keyExtractor={(item) => String(item.id)}
+        renderItem={renderAppointmentItem}
+        ListEmptyComponent={renderEmptyAgenda}
+        contentContainerStyle={[
+          styles.listContainer,
+          appointments.length === 0 && styles.emptyListContainer,
+          { paddingBottom: 96 + bottomInset },
+        ]}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+        alwaysBounceVertical
+      />
 
       <TouchableOpacity style={[styles.fab, { bottom: 16 + bottomInset }]} onPress={openCreateModal}>
         <Ionicons name="add" size={28} color={colors.white} />
@@ -1146,6 +1187,8 @@ const AgendaScreen = () => {
                 onChangeText={(value) => setForm((prev) => ({ ...prev, notes: value }))}
               />
 
+              {renderInlineFeedback()}
+
               <View style={styles.modalButtonsRow}>
                 <TouchableOpacity style={[styles.modalButton, styles.secondaryButton]} onPress={closeModal}>
                   <Text style={[styles.modalButtonText, styles.secondaryButtonText]}>Fechar</Text>
@@ -1173,25 +1216,25 @@ const AgendaScreen = () => {
             onCancel={handleStartPickerCancel}
             onConfirm={handleStartPickerConfirm}
           />
+
+          {submitting && (
+            <View style={styles.loadingOverlay} pointerEvents="auto">
+              <View style={styles.loadingBox}>
+                <ActivityIndicator size="large" color={colors.primary} />
+              </View>
+            </View>
+          )}
         </View>
       </Modal>
 
       <FeedbackModal
-        visible={feedback.visible}
+        visible={feedback.visible && !modalVisible}
         type={feedback.type}
         title={feedback.title}
         message={feedback.message}
         buttonText={feedback.buttonText}
         onClose={hideFeedback}
       />
-
-      <Modal visible={submitting} transparent animationType="fade" statusBarTranslucent>
-        <View style={styles.loadingOverlay}>
-          <View style={styles.loadingBox}>
-            <ActivityIndicator size="large" color={colors.primary} />
-          </View>
-        </View>
-      </Modal>
     </View>
   );
 };
@@ -1277,6 +1320,12 @@ const styles = StyleSheet.create({
   },
   listContainer: {
     paddingBottom: 120,
+  },
+  list: {
+    flex: 1,
+  },
+  emptyListContainer: {
+    flexGrow: 1,
   },
   card: {
     backgroundColor: colors.white,
@@ -1619,6 +1668,40 @@ const styles = StyleSheet.create({
   helperText: {
     color: colors.darkGray,
     fontSize: 12,
+  },
+  inlineFeedback: {
+    marginTop: 12,
+    borderLeftWidth: 4,
+    borderRadius: 10,
+    padding: 12,
+    backgroundColor: colors.inputBackground,
+  },
+  inlineFeedbackHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  inlineFeedbackTitle: {
+    flex: 1,
+    color: colors.text,
+    fontSize: 14,
+    fontWeight: '800',
+  },
+  inlineFeedbackMessage: {
+    marginTop: 6,
+    color: colors.darkGray,
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  inlineFeedbackButton: {
+    alignSelf: 'flex-start',
+    marginTop: 8,
+    paddingVertical: 4,
+    paddingRight: 8,
+  },
+  inlineFeedbackButtonText: {
+    fontSize: 13,
+    fontWeight: '800',
   },
   modalButtonsRow: {
     flexDirection: 'row',

--- a/src/screens/calendar/AgendaScreen.jsx
+++ b/src/screens/calendar/AgendaScreen.jsx
@@ -1,9 +1,7 @@
 ﻿import React, { useEffect, useMemo, useState } from 'react';
 import {
-  ActivityIndicator,
   Alert,
   FlatList,
-  Modal,
   RefreshControl,
   ScrollView,
   StyleSheet,
@@ -1004,7 +1002,7 @@ const AgendaScreen = () => {
         <Ionicons name="add" size={28} color={colors.white} />
       </TouchableOpacity>
 
-      <Modal visible={modalVisible} animationType="slide" onRequestClose={closeModal}>
+      {modalVisible && (
         <View style={styles.modalOverlay}>
           <View style={[styles.modalContent, { paddingTop: 14 + insets.top, paddingBottom: 14 + bottomInset }]}>
             <ScrollView showsVerticalScrollIndicator={false}>
@@ -1217,15 +1215,8 @@ const AgendaScreen = () => {
             onConfirm={handleStartPickerConfirm}
           />
 
-          {submitting && (
-            <View style={styles.loadingOverlay} pointerEvents="auto">
-              <View style={styles.loadingBox}>
-                <ActivityIndicator size="large" color={colors.primary} />
-              </View>
-            </View>
-          )}
         </View>
-      </Modal>
+      )}
 
       <FeedbackModal
         visible={feedback.visible && !modalVisible}
@@ -1255,20 +1246,6 @@ const styles = StyleSheet.create({
   loadingText: {
     fontSize: 16,
     color: colors.darkGray,
-  },
-  loadingOverlay: {
-    ...StyleSheet.absoluteFillObject,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: 'rgba(0, 0, 0, 0.35)',
-  },
-  loadingBox: {
-    width: 88,
-    height: 88,
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderRadius: 16,
-    backgroundColor: 'rgba(255, 255, 255, 0.95)',
   },
   headerRow: {
     flexDirection: 'row',
@@ -1478,9 +1455,14 @@ const styles = StyleSheet.create({
     shadowRadius: 4,
   },
   modalOverlay: {
-    flex: 1,
+    position: 'absolute',
+    top: -56,
+    left: -16,
+    right: -16,
+    bottom: 0,
     backgroundColor: colors.white,
-    position: 'relative',
+    zIndex: 20,
+    elevation: 20,
   },
   modalContent: {
     flex: 1,


### PR DESCRIPTION
## O que mudou

- remove os offsets negativos que faziam a tela inline do agendamento exceder o viewport;
- limita o overlay à área real disponível com `StyleSheet.absoluteFillObject`;
- bloqueia overflow visual nas bordas;
- mantém o conteúdo rolável e os taps funcionais durante o preenchimento;
- incrementa a versão visível do app para `1.1.6` sem alterar o runtime nativo.

## Causa raiz

Ao substituir o `Modal` nativo por uma camada inline, o overlay recebeu `top: -56`, `left: -16` e `right: -16`. Isso criava uma área 32 px mais larga e 56 px mais alta que o contêiner, causando o efeito de zoom/corte em iOS e Android.

## Validações

- parse/transpilação Babel de `AgendaScreen.jsx`;
- parse JSON de `package.json`, `package-lock.json` e `app.json`;
- `git diff --check`.

## Observação

Este PR parte da branch da correção anterior da Agenda e substitui o draft #82, incluindo os ajustes que removeram o modal nativo.

Closes #85