### PR TITLE
fix: permite agendamento com conflito de horário

### DIFF
--- a/APP_GUIDELINES.md
+++ b/APP_GUIDELINES.md
@@ -103,7 +103,7 @@ Evitar lógica espalhada entre telas. Regras de negócio devem ficar centralizad
 4. integração com Google Calendar
 5. lembretes automáticos
 
-Financeiro e regras para agendamentos concluídos/cancelados não são prioridade imediata. Antes de qualquer implementação financeira real, definir como esses status afetam os cálculos. O sinal, por enquanto, tem regra simples: padrão de 30% do valor total, por agendamento, ajustável por seletor de percentual ou por valor manual em R$, com exibição de quanto falta pagar e sem configuração por serviço.
+Financeiro e regras para agendamentos concluídos/cancelados não são prioridade imediata. Antes de qualquer implementação financeira real, definir como esses status afetam os cálculos. O sinal, por enquanto, tem regra simples: padrão de 0% do valor total, por agendamento, ajustável por seletor de percentual ou por valor manual em R$, com exibição de quanto falta pagar e sem configuração por serviço.
 
 Evitar funcionalidades complexas antes da validação de uso real do fluxo principal.
 

--- a/APP_GUIDELINES.md
+++ b/APP_GUIDELINES.md
@@ -52,6 +52,8 @@ Ordem ideal:
 
 Esse fluxo é prioridade máxima em qualquer decisão de UX e de backend.
 
+Conflitos de horário devem gerar um aviso claro, com opções para ajustar o horário ou agendar mesmo assim. Depois da confirmação explícita da profissional, a sobreposição não deve bloquear a criação ou edição do agendamento.
+
 ## Princípios de UX
 
 ### Redução de carga cognitiva

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beautyapp",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beautyapp",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "0BSD",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beautyapp",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beautyapp",
-      "version": "1.1.6",
+      "version": "1.2.0",
       "license": "0BSD",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beautyapp",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beautyapp",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "0BSD",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beautyapp",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beautyapp",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "0BSD",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beautyapp",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beautyapp",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "0BSD",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beautyapp",
   "license": "0BSD",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "main": "index.js",
   "scripts": {
     "start": "npx expo start --clear --go",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beautyapp",
   "license": "0BSD",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "main": "index.js",
   "scripts": {
     "start": "npx expo start --clear --go",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beautyapp",
   "license": "0BSD",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "main": "index.js",
   "scripts": {
     "start": "npx expo start --clear --go",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beautyapp",
   "license": "0BSD",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "index.js",
   "scripts": {
     "start": "npx expo start --clear --go",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beautyapp",
   "license": "0BSD",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "main": "index.js",
   "scripts": {
     "start": "npx expo start --clear --go",

--- a/src/screens/calendar/AgendaScreen.jsx
+++ b/src/screens/calendar/AgendaScreen.jsx
@@ -1005,7 +1005,12 @@ const AgendaScreen = () => {
       {modalVisible && (
         <View style={styles.modalOverlay}>
           <View style={[styles.modalContent, { paddingTop: 14 + insets.top, paddingBottom: 14 + bottomInset }]}>
-            <ScrollView showsVerticalScrollIndicator={false}>
+            <ScrollView
+              style={styles.modalScroll}
+              contentContainerStyle={styles.modalScrollContent}
+              showsVerticalScrollIndicator={false}
+              keyboardShouldPersistTaps="handled"
+            >
               <Text style={styles.modalTitle}>{isEditing ? 'Editar agendamento' : 'Novo agendamento'}</Text>
 
               <Text style={styles.fieldLabel}>Cliente</Text>
@@ -1455,12 +1460,9 @@ const styles = StyleSheet.create({
     shadowRadius: 4,
   },
   modalOverlay: {
-    position: 'absolute',
-    top: -56,
-    left: -16,
-    right: -16,
-    bottom: 0,
+    ...StyleSheet.absoluteFillObject,
     backgroundColor: colors.white,
+    overflow: 'hidden',
     zIndex: 20,
     elevation: 20,
   },
@@ -1468,6 +1470,12 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: colors.white,
     paddingHorizontal: 14,
+  },
+  modalScroll: {
+    flex: 1,
+  },
+  modalScrollContent: {
+    flexGrow: 1,
   },
   modalTitle: {
     fontSize: 19,

--- a/src/screens/calendar/AgendaScreen.jsx
+++ b/src/screens/calendar/AgendaScreen.jsx
@@ -30,7 +30,7 @@ const SLOT_STEP_MINUTES = 30;
 const DAY_START_HOUR = 8;
 const DAY_END_HOUR = 19;
 const CLIENT_SEARCH_LIMIT = 30;
-const DEFAULT_DEPOSIT_PERCENT = 30;
+const DEFAULT_DEPOSIT_PERCENT = 0;
 const DEPOSIT_PERCENT_OPTIONS = [0, 15, 30];
 
 const statusLabels = {

--- a/src/screens/calendar/AgendaScreen.jsx
+++ b/src/screens/calendar/AgendaScreen.jsx
@@ -1,6 +1,7 @@
 ﻿import React, { useEffect, useMemo, useState } from 'react';
 import {
   Alert,
+  BackHandler,
   FlatList,
   RefreshControl,
   ScrollView,
@@ -581,7 +582,7 @@ const AgendaScreen = () => {
     setModalVisible(true);
   };
 
-  const closeModal = () => {
+  const closeModal = React.useCallback(() => {
     setModalVisible(false);
     setShowStartPicker(false);
     setStartPickerMode('date');
@@ -590,7 +591,7 @@ const AgendaScreen = () => {
     setClientSearch('');
     setServiceSearch('');
     setClientSearchLoading(false);
-  };
+  }, [hideFeedback]);
 
   const openStartPicker = (mode) => {
     setStartPickerMode(mode);
@@ -620,10 +621,32 @@ const AgendaScreen = () => {
     setStartPickerMode('date');
   };
 
-  const handleStartPickerCancel = () => {
+  const handleStartPickerCancel = React.useCallback(() => {
     setShowStartPicker(false);
     setStartPickerMode('date');
-  };
+  }, []);
+
+  useEffect(() => {
+    if (!modalVisible) {
+      return undefined;
+    }
+
+    const backSubscription = BackHandler.addEventListener('hardwareBackPress', () => {
+      if (showStartPicker) {
+        handleStartPickerCancel();
+        return true;
+      }
+
+      if (submitting) {
+        return true;
+      }
+
+      closeModal();
+      return true;
+    });
+
+    return () => backSubscription.remove();
+  }, [closeModal, handleStartPickerCancel, modalVisible, showStartPicker, submitting]);
 
   const handleDepositPercentPress = (percent) => {
     const nextDepositAmount = calculateDepositAmount(selectedServicesTotal.price, percent);
@@ -1193,7 +1216,15 @@ const AgendaScreen = () => {
               {renderInlineFeedback()}
 
               <View style={styles.modalButtonsRow}>
-                <TouchableOpacity style={[styles.modalButton, styles.secondaryButton]} onPress={closeModal}>
+                <TouchableOpacity
+                  style={[
+                    styles.modalButton,
+                    styles.secondaryButton,
+                    submitting && styles.disabledButton,
+                  ]}
+                  onPress={closeModal}
+                  disabled={submitting}
+                >
                   <Text style={[styles.modalButtonText, styles.secondaryButtonText]}>Fechar</Text>
                 </TouchableOpacity>
                 <TouchableOpacity

--- a/src/screens/calendar/AgendaScreen.jsx
+++ b/src/screens/calendar/AgendaScreen.jsx
@@ -506,7 +506,16 @@ const AgendaScreen = () => {
 
   const onRefresh = async () => {
     setRefreshing(true);
-    await Promise.all([loadClientsAndServices(), loadAgenda({ isRefresh: true })]);
+    try {
+      await Promise.all([loadClientsAndServices(), loadAgenda({ isRefresh: true })]);
+    } catch (error) {
+      console.error('Erro ao atualizar agenda:', error.response?.data || error.message);
+      if (!isSessionExpiredError(error)) {
+        Alert.alert('Erro', 'Não foi possível atualizar os dados da agenda.');
+      }
+    } finally {
+      setRefreshing(false);
+    }
   };
 
   const openCreateModal = async () => {
@@ -579,6 +588,7 @@ const AgendaScreen = () => {
     setShowStartPicker(false);
     setStartPickerMode('date');
     setSubmitting(false);
+    hideFeedback();
     setClientSearch('');
     setServiceSearch('');
     setClientSearchLoading(false);
@@ -879,6 +889,55 @@ const AgendaScreen = () => {
     </View>
   );
 
+  const renderEmptyAgenda = () => (
+    <View style={styles.emptyState}>
+      <Ionicons name="calendar-clear-outline" size={64} color={colors.lightGray} />
+      <Text style={styles.emptyTitle}>Nenhum agendamento neste dia</Text>
+      <Text style={styles.emptySubtitle}>Crie seu primeiro agendamento em poucos toques.</Text>
+
+      {!canSchedule && (
+        <View style={styles.emptyActions}>
+          <TouchableOpacity
+            style={styles.emptyActionButton}
+            onPress={() => navigation.navigate('RegisterCustomer')}
+          >
+            <Text style={styles.emptyActionText}>Cadastrar Cliente</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.emptyActionButton}
+            onPress={() => navigation.navigate('RegisterService')}
+          >
+            <Text style={styles.emptyActionText}>Cadastrar Serviço</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+    </View>
+  );
+
+  const renderInlineFeedback = () => {
+    if (!feedback.visible) {
+      return null;
+    }
+
+    const feedbackColor = feedback.type === 'error' ? colors.secondary : colors.primary;
+    const feedbackIcon = feedback.type === 'error' ? 'alert-circle' : 'checkmark-circle';
+
+    return (
+      <View style={[styles.inlineFeedback, { borderLeftColor: feedbackColor }]}>
+        <View style={styles.inlineFeedbackHeader}>
+          <Ionicons name={feedbackIcon} size={18} color={feedbackColor} />
+          <Text style={styles.inlineFeedbackTitle}>{feedback.title || 'Atenção'}</Text>
+        </View>
+        {feedback.message ? <Text style={styles.inlineFeedbackMessage}>{feedback.message}</Text> : null}
+        <TouchableOpacity style={styles.inlineFeedbackButton} onPress={hideFeedback}>
+          <Text style={[styles.inlineFeedbackButtonText, { color: feedbackColor }]}>
+            {feedback.buttonText || 'OK'}
+          </Text>
+        </TouchableOpacity>
+      </View>
+    );
+  };
+
   if (loading) {
     return (
       <View style={styles.loadingContainer}>
@@ -926,38 +985,20 @@ const AgendaScreen = () => {
         </View>
       </View>
 
-      {appointments.length === 0 ? (
-        <View style={styles.emptyState}>
-          <Ionicons name="calendar-clear-outline" size={64} color={colors.lightGray} />
-          <Text style={styles.emptyTitle}>Nenhum agendamento neste dia</Text>
-          <Text style={styles.emptySubtitle}>Crie seu primeiro agendamento em poucos toques.</Text>
-
-          {!canSchedule && (
-            <View style={styles.emptyActions}>
-              <TouchableOpacity
-                style={styles.emptyActionButton}
-                onPress={() => navigation.navigate('RegisterCustomer')}
-              >
-                <Text style={styles.emptyActionText}>Cadastrar Cliente</Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={styles.emptyActionButton}
-                onPress={() => navigation.navigate('RegisterService')}
-              >
-                <Text style={styles.emptyActionText}>Cadastrar Serviço</Text>
-              </TouchableOpacity>
-            </View>
-          )}
-        </View>
-      ) : (
-        <FlatList
-          data={appointments}
-          keyExtractor={(item) => String(item.id)}
-          renderItem={renderAppointmentItem}
-          contentContainerStyle={[styles.listContainer, { paddingBottom: 96 + bottomInset }]}
-          refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
-        />
-      )}
+      <FlatList
+        style={styles.list}
+        data={appointments}
+        keyExtractor={(item) => String(item.id)}
+        renderItem={renderAppointmentItem}
+        ListEmptyComponent={renderEmptyAgenda}
+        contentContainerStyle={[
+          styles.listContainer,
+          appointments.length === 0 && styles.emptyListContainer,
+          { paddingBottom: 96 + bottomInset },
+        ]}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+        alwaysBounceVertical
+      />
 
       <TouchableOpacity style={[styles.fab, { bottom: 16 + bottomInset }]} onPress={openCreateModal}>
         <Ionicons name="add" size={28} color={colors.white} />
@@ -1146,6 +1187,8 @@ const AgendaScreen = () => {
                 onChangeText={(value) => setForm((prev) => ({ ...prev, notes: value }))}
               />
 
+              {renderInlineFeedback()}
+
               <View style={styles.modalButtonsRow}>
                 <TouchableOpacity style={[styles.modalButton, styles.secondaryButton]} onPress={closeModal}>
                   <Text style={[styles.modalButtonText, styles.secondaryButtonText]}>Fechar</Text>
@@ -1173,25 +1216,25 @@ const AgendaScreen = () => {
             onCancel={handleStartPickerCancel}
             onConfirm={handleStartPickerConfirm}
           />
+
+          {submitting && (
+            <View style={styles.loadingOverlay} pointerEvents="auto">
+              <View style={styles.loadingBox}>
+                <ActivityIndicator size="large" color={colors.primary} />
+              </View>
+            </View>
+          )}
         </View>
       </Modal>
 
       <FeedbackModal
-        visible={feedback.visible}
+        visible={feedback.visible && !modalVisible}
         type={feedback.type}
         title={feedback.title}
         message={feedback.message}
         buttonText={feedback.buttonText}
         onClose={hideFeedback}
       />
-
-      <Modal visible={submitting} transparent animationType="fade" statusBarTranslucent>
-        <View style={styles.loadingOverlay}>
-          <View style={styles.loadingBox}>
-            <ActivityIndicator size="large" color={colors.primary} />
-          </View>
-        </View>
-      </Modal>
     </View>
   );
 };
@@ -1277,6 +1320,12 @@ const styles = StyleSheet.create({
   },
   listContainer: {
     paddingBottom: 120,
+  },
+  list: {
+    flex: 1,
+  },
+  emptyListContainer: {
+    flexGrow: 1,
   },
   card: {
     backgroundColor: colors.white,
@@ -1619,6 +1668,40 @@ const styles = StyleSheet.create({
   helperText: {
     color: colors.darkGray,
     fontSize: 12,
+  },
+  inlineFeedback: {
+    marginTop: 12,
+    borderLeftWidth: 4,
+    borderRadius: 10,
+    padding: 12,
+    backgroundColor: colors.inputBackground,
+  },
+  inlineFeedbackHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  inlineFeedbackTitle: {
+    flex: 1,
+    color: colors.text,
+    fontSize: 14,
+    fontWeight: '800',
+  },
+  inlineFeedbackMessage: {
+    marginTop: 6,
+    color: colors.darkGray,
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  inlineFeedbackButton: {
+    alignSelf: 'flex-start',
+    marginTop: 8,
+    paddingVertical: 4,
+    paddingRight: 8,
+  },
+  inlineFeedbackButtonText: {
+    fontSize: 13,
+    fontWeight: '800',
   },
   modalButtonsRow: {
     flexDirection: 'row',

--- a/src/screens/calendar/AgendaScreen.jsx
+++ b/src/screens/calendar/AgendaScreen.jsx
@@ -1,9 +1,7 @@
 ﻿import React, { useEffect, useMemo, useState } from 'react';
 import {
-  ActivityIndicator,
   Alert,
   FlatList,
-  Modal,
   RefreshControl,
   ScrollView,
   StyleSheet,
@@ -1004,7 +1002,7 @@ const AgendaScreen = () => {
         <Ionicons name="add" size={28} color={colors.white} />
       </TouchableOpacity>
 
-      <Modal visible={modalVisible} animationType="slide" onRequestClose={closeModal}>
+      {modalVisible && (
         <View style={styles.modalOverlay}>
           <View style={[styles.modalContent, { paddingTop: 14 + insets.top, paddingBottom: 14 + bottomInset }]}>
             <ScrollView showsVerticalScrollIndicator={false}>
@@ -1217,15 +1215,8 @@ const AgendaScreen = () => {
             onConfirm={handleStartPickerConfirm}
           />
 
-          {submitting && (
-            <View style={styles.loadingOverlay} pointerEvents="auto">
-              <View style={styles.loadingBox}>
-                <ActivityIndicator size="large" color={colors.primary} />
-              </View>
-            </View>
-          )}
         </View>
-      </Modal>
+      )}
 
       <FeedbackModal
         visible={feedback.visible && !modalVisible}
@@ -1255,20 +1246,6 @@ const styles = StyleSheet.create({
   loadingText: {
     fontSize: 16,
     color: colors.darkGray,
-  },
-  loadingOverlay: {
-    ...StyleSheet.absoluteFillObject,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: 'rgba(0, 0, 0, 0.35)',
-  },
-  loadingBox: {
-    width: 88,
-    height: 88,
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderRadius: 16,
-    backgroundColor: 'rgba(255, 255, 255, 0.95)',
   },
   headerRow: {
     flexDirection: 'row',
@@ -1478,9 +1455,14 @@ const styles = StyleSheet.create({
     shadowRadius: 4,
   },
   modalOverlay: {
-    flex: 1,
+    position: 'absolute',
+    top: -56,
+    left: -16,
+    right: -16,
+    bottom: 0,
     backgroundColor: colors.white,
-    position: 'relative',
+    zIndex: 20,
+    elevation: 20,
   },
   modalContent: {
     flex: 1,

--- a/src/screens/calendar/AgendaScreen.jsx
+++ b/src/screens/calendar/AgendaScreen.jsx
@@ -15,9 +15,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import DateTimePickerModal from '../../components/DateTimePickerModal';
-import FeedbackModal from '../../components/FeedbackModal';
 import colors from '../../constants/colors';
-import useFeedbackModal from '../../hooks/useFeedbackModal';
 import api from '../../services/api';
 import { isSessionExpiredError } from '../../services/sessionManager';
 import {
@@ -240,7 +238,6 @@ const createBaseSlots = (date) => {
 const AgendaScreen = () => {
   const navigation = useNavigation();
   const insets = useSafeAreaInsets();
-  const { feedback, showFeedback, hideFeedback } = useFeedbackModal();
   const bottomInset = Math.max(insets.bottom, 8);
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [showDayPicker, setShowDayPicker] = useState(false);
@@ -263,6 +260,7 @@ const AgendaScreen = () => {
   const [editingAppointmentId, setEditingAppointmentId] = useState(null);
   const [showStartPicker, setShowStartPicker] = useState(false);
   const [startPickerMode, setStartPickerMode] = useState('date');
+  const [conflictConfirmationVisible, setConflictConfirmationVisible] = useState(false);
 
   const [form, setForm] = useState({
     clientId: null,
@@ -587,11 +585,11 @@ const AgendaScreen = () => {
     setShowStartPicker(false);
     setStartPickerMode('date');
     setSubmitting(false);
-    hideFeedback();
+    setConflictConfirmationVisible(false);
     setClientSearch('');
     setServiceSearch('');
     setClientSearchLoading(false);
-  }, [hideFeedback]);
+  }, []);
 
   const openStartPicker = (mode) => {
     setStartPickerMode(mode);
@@ -708,14 +706,10 @@ const AgendaScreen = () => {
   };
 
   const showAppointmentConflictFeedback = () => {
-    showFeedback({
-      type: 'error',
-      title: 'Conflito de horário',
-      message: 'Já existe outro agendamento neste mesmo horário. Ajuste a data ou o horário e tente novamente.',
-    });
+    setConflictConfirmationVisible(true);
   };
 
-  const handleSaveAppointment = async () => {
+  const handleSaveAppointment = async (allowConflict = false) => {
     if (submitting) {
       return;
     }
@@ -738,7 +732,7 @@ const AgendaScreen = () => {
       return;
     }
 
-    if (hasLocalAppointmentConflict()) {
+    if (!allowConflict && hasLocalAppointmentConflict()) {
       showAppointmentConflictFeedback();
       return;
     }
@@ -749,8 +743,10 @@ const AgendaScreen = () => {
       startAt: form.startAt.toISOString(),
       depositAmount: finalDepositAmount,
       notes: form.notes,
+      ...(allowConflict ? { allowConflict: true } : {}),
     };
 
+    setConflictConfirmationVisible(false);
     setSubmitting(true);
 
     if (isEditing && editingAppointmentId) {
@@ -761,7 +757,7 @@ const AgendaScreen = () => {
         ))));
         closeModal();
       } catch (error) {
-        if (isAppointmentConflictError(error)) {
+        if (!allowConflict && isAppointmentConflictError(error)) {
           showAppointmentConflictFeedback();
           return;
         }
@@ -779,7 +775,7 @@ const AgendaScreen = () => {
       setAppointments((prev) => sortAppointments([...prev, created]));
       closeModal();
     } catch (error) {
-      if (isAppointmentConflictError(error)) {
+      if (!allowConflict && isAppointmentConflictError(error)) {
         showAppointmentConflictFeedback();
         return;
       }
@@ -936,25 +932,37 @@ const AgendaScreen = () => {
   );
 
   const renderInlineFeedback = () => {
-    if (!feedback.visible) {
+    if (!conflictConfirmationVisible) {
       return null;
     }
 
-    const feedbackColor = feedback.type === 'error' ? colors.secondary : colors.primary;
-    const feedbackIcon = feedback.type === 'error' ? 'alert-circle' : 'checkmark-circle';
-
     return (
-      <View style={[styles.inlineFeedback, { borderLeftColor: feedbackColor }]}>
+      <View style={[styles.inlineFeedback, { borderLeftColor: colors.warning }]}>
         <View style={styles.inlineFeedbackHeader}>
-          <Ionicons name={feedbackIcon} size={18} color={feedbackColor} />
-          <Text style={styles.inlineFeedbackTitle}>{feedback.title || 'Atenção'}</Text>
+          <Ionicons name="alert-circle" size={18} color={colors.warning} />
+          <Text style={styles.inlineFeedbackTitle}>Conflito de horário</Text>
         </View>
-        {feedback.message ? <Text style={styles.inlineFeedbackMessage}>{feedback.message}</Text> : null}
-        <TouchableOpacity style={styles.inlineFeedbackButton} onPress={hideFeedback}>
-          <Text style={[styles.inlineFeedbackButtonText, { color: feedbackColor }]}>
-            {feedback.buttonText || 'OK'}
-          </Text>
-        </TouchableOpacity>
+        <Text style={styles.inlineFeedbackMessage}>
+          Já existe outro agendamento neste horário. Você pode ajustar o horário ou salvar mesmo assim.
+        </Text>
+        <View style={styles.inlineFeedbackActions}>
+          <TouchableOpacity
+            style={[styles.inlineFeedbackAction, styles.inlineFeedbackSecondaryAction]}
+            onPress={() => setConflictConfirmationVisible(false)}
+            disabled={submitting}
+          >
+            <Text style={styles.inlineFeedbackSecondaryActionText}>Ajustar horário</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.inlineFeedbackAction, styles.inlineFeedbackPrimaryAction]}
+            onPress={() => handleSaveAppointment(true)}
+            disabled={submitting}
+          >
+            <Text style={styles.inlineFeedbackPrimaryActionText}>
+              {submitting ? 'Salvando...' : 'Agendar mesmo assim'}
+            </Text>
+          </TouchableOpacity>
+        </View>
       </View>
     );
   };
@@ -1229,7 +1237,7 @@ const AgendaScreen = () => {
                 </TouchableOpacity>
                 <TouchableOpacity
                   style={[styles.modalButton, styles.primaryButton, submitting && styles.disabledButton]}
-                  onPress={handleSaveAppointment}
+                  onPress={() => handleSaveAppointment()}
                   disabled={submitting}
                 >
                   <Text style={styles.modalButtonText}>{submitting ? 'Salvando...' : 'Confirmar'}</Text>
@@ -1254,14 +1262,6 @@ const AgendaScreen = () => {
         </View>
       )}
 
-      <FeedbackModal
-        visible={feedback.visible && !modalVisible}
-        type={feedback.type}
-        title={feedback.title}
-        message={feedback.message}
-        buttonText={feedback.buttonText}
-        onClose={hideFeedback}
-      />
     </View>
   );
 };
@@ -1714,15 +1714,39 @@ const styles = StyleSheet.create({
     fontSize: 13,
     lineHeight: 18,
   },
-  inlineFeedbackButton: {
-    alignSelf: 'flex-start',
-    marginTop: 8,
-    paddingVertical: 4,
-    paddingRight: 8,
+  inlineFeedbackActions: {
+    flexDirection: 'row',
+    gap: 8,
+    marginTop: 10,
   },
-  inlineFeedbackButtonText: {
+  inlineFeedbackAction: {
+    flex: 1,
+    minHeight: 40,
+    borderRadius: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 8,
+    paddingVertical: 8,
+  },
+  inlineFeedbackSecondaryAction: {
+    borderWidth: 1,
+    borderColor: colors.primary,
+    backgroundColor: colors.white,
+  },
+  inlineFeedbackPrimaryAction: {
+    backgroundColor: colors.primary,
+  },
+  inlineFeedbackSecondaryActionText: {
+    color: colors.primary,
     fontSize: 13,
     fontWeight: '800',
+    textAlign: 'center',
+  },
+  inlineFeedbackPrimaryActionText: {
+    color: colors.white,
+    fontSize: 13,
+    fontWeight: '800',
+    textAlign: 'center',
   },
   modalButtonsRow: {
     flexDirection: 'row',

--- a/src/screens/clients/registerCustomer.jsx
+++ b/src/screens/clients/registerCustomer.jsx
@@ -110,6 +110,14 @@ export default function RegisterClientScreeen() {
           <TextInput
             style={styles.input}
             mode="outlined"
+            label="Sobrenome"
+            value={formData.lastName}
+            onChangeText={(value) => handleInputChange('lastName', value)}
+          />
+
+          <TextInput
+            style={styles.input}
+            mode="outlined"
             label="Telefone"
             placeholder="+55"
             keyboardType="phone-pad"
@@ -130,14 +138,6 @@ export default function RegisterClientScreeen() {
 
           {showOptionalFields && (
             <View style={styles.optionalFields}>
-              <TextInput
-                style={styles.input}
-                mode="outlined"
-                label="Sobrenome"
-                value={formData.lastName}
-                onChangeText={(value) => handleInputChange('lastName', value)}
-              />
-
               <TextInput
                 style={styles.input}
                 mode="outlined"


### PR DESCRIPTION
## O que mudou

- transforma o conflito de horário em confirmação inline;
- oferece `Ajustar horário` e `Agendar mesmo assim`;
- reenvia criação/edição com `allowConflict: true` somente após confirmação explícita;
- atualiza a versão visível para `1.2.1`, preservando o runtime OTA em `app.json`.

## Motivo

A validação local e o retorno `409` da API impediam qualquer sobreposição, mesmo quando ela era intencional para a profissional.

## Impacto

Sem conflito, o fluxo continua igual. Com conflito, o formulário permanece preenchido e a profissional decide se ajusta o horário ou salva mesmo assim.

Esta branch também preserva a sequência ainda não integrada das correções da Agenda e do cadastro presentes em `fix/BEAUTY-81`, `fix/BEAUTY-85` e `feat/BEAUTY-87`.

## Validações

- parse/transpilação Babel de `AgendaScreen.jsx`;
- parse JSON de `package.json`, `package-lock.json` e `app.json`;
- `git diff --check`.

Issue: #89