### PR TITLE
feat: agenda por dia a partir de hoje e sinal em tempo real

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beautyapp",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beautyapp",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "0BSD",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beautyapp",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beautyapp",
-      "version": "1.3.3",
+      "version": "1.4.0",
       "license": "0BSD",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beautyapp",
   "license": "0BSD",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "main": "index.js",
   "scripts": {
     "start": "npx expo start --clear --go",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beautyapp",
   "license": "0BSD",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "main": "index.js",
   "scripts": {
     "start": "npx expo start --clear --go",

--- a/src/hooks/useCurrencyInput.js
+++ b/src/hooks/useCurrencyInput.js
@@ -1,0 +1,85 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  applyCurrencyInputChange,
+  createCurrencyBufferFromAmount,
+  createEmptyCurrencyBuffer,
+  formatCurrencyBuffer,
+  getCurrencyBufferAmount,
+  getCurrencyBufferSelection,
+  isSameCurrencyAmount,
+} from '../utils/currency';
+
+// Liga o buffer de digitos de `utils/currency` a um TextInput controlado.
+//
+// O cursor precisa ser controlado por nos: com as duas casas decimais sempre
+// visiveis, deixar o cursor no fim faria todo digito novo cair nos centavos.
+// `selection` fica em state (e nao montado inline no JSX) porque o Android
+// reenvia a selecao ao nativo sempre que a identidade do objeto muda, e o
+// formulario re-renderiza a cada tecla por causa do "Falta pagar".
+const useCurrencyInput = ({
+  value = 0,
+  syncToken = 0,
+  onChangeValue,
+  clearOnFocusWhenZero = true,
+}) => {
+  const bufferRef = useRef(createCurrencyBufferFromAmount(value));
+  const onChangeValueRef = useRef(onChangeValue);
+  const [text, setText] = useState(() => formatCurrencyBuffer(bufferRef.current));
+  const [selection, setSelection] = useState(() => getCurrencyBufferSelection(bufferRef.current));
+
+  useEffect(() => {
+    onChangeValueRef.current = onChangeValue;
+  }, [onChangeValue]);
+
+  const applyBuffer = useCallback((nextBuffer) => {
+    bufferRef.current = nextBuffer;
+    setText(formatCurrencyBuffer(nextBuffer));
+    setSelection(getCurrencyBufferSelection(nextBuffer));
+  }, []);
+
+  // Sincroniza com mudancas vindas de fora (chips de percentual, recalculo por
+  // servico, abrir o formulario). O eco do proprio onChangeValue cai aqui como
+  // no-op, entao nao ha laco.
+  useEffect(() => {
+    if (isSameCurrencyAmount(getCurrencyBufferAmount(bufferRef.current), value)) {
+      return;
+    }
+    applyBuffer(createCurrencyBufferFromAmount(value));
+  }, [applyBuffer, value]);
+
+  // Redesenho forcado para os casos em que o valor externo nao muda mas o texto
+  // precisa voltar ao normalizado: chip 0% com o campo ja zerado, reabrir o modal.
+  useEffect(() => {
+    applyBuffer(createCurrencyBufferFromAmount(value));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [syncToken]);
+
+  const handleChangeText = useCallback((nextText) => {
+    const nextBuffer = applyCurrencyInputChange(bufferRef.current, nextText);
+    applyBuffer(nextBuffer);
+    onChangeValueRef.current?.(getCurrencyBufferAmount(nextBuffer));
+  }, [applyBuffer]);
+
+  const handleFocus = useCallback(() => {
+    if (!clearOnFocusWhenZero || getCurrencyBufferAmount(bufferRef.current) !== 0) {
+      return;
+    }
+    // Esvazia sem avisar o dono do valor: continua sendo 0, entao tocar no campo
+    // nao pode desmarcar o chip de percentual. So digitar desmarca.
+    applyBuffer(createEmptyCurrencyBuffer());
+  }, [applyBuffer, clearOnFocusWhenZero]);
+
+  const handleBlur = useCallback(() => {
+    applyBuffer(createCurrencyBufferFromAmount(getCurrencyBufferAmount(bufferRef.current)));
+  }, [applyBuffer]);
+
+  return {
+    value: text,
+    selection,
+    onChangeText: handleChangeText,
+    onFocus: handleFocus,
+    onBlur: handleBlur,
+  };
+};
+
+export default useCurrencyInput;

--- a/src/screens/calendar/AgendaScreen.jsx
+++ b/src/screens/calendar/AgendaScreen.jsx
@@ -22,6 +22,15 @@ import { useNavigation } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import DateTimePickerModal from '../../components/DateTimePickerModal';
 import colors from '../../constants/colors';
+import useCurrencyInput from '../../hooks/useCurrencyInput';
+import {
+  calculateDepositAmount,
+  calculateRemainingAmount,
+  formatCurrency,
+  inferDepositPercent,
+  isSameCurrencyAmount,
+  roundCurrency,
+} from '../../utils/currency';
 import api from '../../services/api';
 import { isSessionExpiredError } from '../../services/sessionManager';
 import {
@@ -189,71 +198,10 @@ const isSameLocalDay = (firstDate, secondDate) => (
   getLocalDateKey(firstDate) === getLocalDateKey(secondDate)
 );
 
-const formatCurrency = (value = 0) => Number(value).toLocaleString('pt-BR', {
-  style: 'currency',
-  currency: 'BRL',
-});
-
-const roundCurrency = (value = 0) => Math.round((Number(value || 0) + Number.EPSILON) * 100) / 100;
-
 const calculateServicesTotal = (services) => services.reduce((totals, service) => ({
   price: totals.price + Number(service.price || 0),
   estimatedTime: totals.estimatedTime + Number(service.estimatedTime || 0),
 }), { price: 0, estimatedTime: 0 });
-
-const calculateDepositAmount = (price = 0, percent = DEFAULT_DEPOSIT_PERCENT) => (
-  roundCurrency((Number(price || 0) * Number(percent || 0)) / 100)
-);
-
-const formatCurrencyInput = (value = 0) => roundCurrency(value).toLocaleString('pt-BR', {
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
-});
-
-const sanitizeCurrencyInput = (value = '') => String(value).replace(/[^\d.,]/g, '');
-
-const parseCurrencyInput = (value = '') => {
-  if (typeof value === 'number') {
-    return Number.isFinite(value) ? roundCurrency(value) : null;
-  }
-
-  const sanitizedValue = sanitizeCurrencyInput(value);
-  if (!sanitizedValue) {
-    return 0;
-  }
-
-  const lastComma = sanitizedValue.lastIndexOf(',');
-  const lastDot = sanitizedValue.lastIndexOf('.');
-  const normalizedValue = lastComma > lastDot
-    ? sanitizedValue.replace(/\./g, '').replace(',', '.')
-    : sanitizedValue.replace(/,/g, '');
-  const parsedValue = Number(normalizedValue);
-
-  return Number.isFinite(parsedValue) ? roundCurrency(parsedValue) : null;
-};
-
-const calculateRemainingAmount = (price = 0, depositAmount = 0) => {
-  const total = Math.max(Number(price || 0), 0);
-  const deposit = Math.max(Number(depositAmount || 0), 0);
-  return roundCurrency(Math.max(total - deposit, 0));
-};
-
-const isSameCurrencyAmount = (firstValue = 0, secondValue = 0) => (
-  Math.abs(roundCurrency(firstValue) - roundCurrency(secondValue)) < 0.01
-);
-
-const inferDepositPercent = (depositAmount = 0, price = 0) => {
-  const numericPrice = Number(price || 0);
-  const numericDeposit = Number(depositAmount || 0);
-
-  if (!numericPrice || !Number.isFinite(numericPrice) || !Number.isFinite(numericDeposit)) {
-    return null;
-  }
-
-  return DEPOSIT_PERCENT_OPTIONS.find((option) => (
-    isSameCurrencyAmount(calculateDepositAmount(numericPrice, option), numericDeposit)
-  )) ?? null;
-};
 
 const formatDateLabel = (date) => date.toLocaleDateString('pt-BR', {
   weekday: 'long',
@@ -352,10 +300,12 @@ const AgendaScreen = () => {
     startAt: new Date(),
     depositPercent: DEFAULT_DEPOSIT_PERCENT,
     depositAmount: 0,
-    depositAmountInput: formatCurrencyInput(0),
     depositMode: 'percent',
     notes: '',
   });
+  // Forca o campo de sinal a redesenhar quando o valor externo nao muda de numero
+  // mas o texto precisa voltar ao normalizado (chip 0% com campo zerado, reabrir o modal).
+  const [depositSyncToken, setDepositSyncToken] = useState(0);
 
   const canSchedule = hasClientRecords && services.length > 0;
   const markedDates = calendarMarksByMonth[getMonthKey(visibleCalendarMonth)] || [];
@@ -725,22 +675,12 @@ const AgendaScreen = () => {
 
     const percent = form.depositPercent ?? DEFAULT_DEPOSIT_PERCENT;
     const nextDepositAmount = calculateDepositAmount(selectedServicesTotal.price, percent);
-    const nextDepositAmountInput = formatCurrencyInput(nextDepositAmount);
 
-    setForm((prev) => {
-      if (
-        isSameCurrencyAmount(prev.depositAmount, nextDepositAmount)
-        && prev.depositAmountInput === nextDepositAmountInput
-      ) {
-        return prev;
-      }
-
-      return {
-        ...prev,
-        depositAmount: nextDepositAmount,
-        depositAmountInput: nextDepositAmountInput,
-      };
-    });
+    setForm((prev) => (
+      isSameCurrencyAmount(prev.depositAmount, nextDepositAmount)
+        ? prev
+        : { ...prev, depositAmount: nextDepositAmount }
+    ));
   }, [form.depositMode, form.depositPercent, modalVisible, selectedServicesTotal.price]);
 
   const onRefresh = async () => {
@@ -787,10 +727,10 @@ const AgendaScreen = () => {
       startAt: defaultStartAt,
       depositPercent: DEFAULT_DEPOSIT_PERCENT,
       depositAmount: 0,
-      depositAmountInput: formatCurrencyInput(0),
       depositMode: 'percent',
       notes: '',
     });
+    setDepositSyncToken((token) => token + 1);
 
     setModalVisible(true);
   };
@@ -804,7 +744,11 @@ const AgendaScreen = () => {
     setServiceSearch('');
     const appointmentServiceIds = getAppointmentServiceIds(appointment);
     const appointmentDepositAmount = roundCurrency(Number(appointment.depositAmount || 0));
-    const appointmentDepositPercent = inferDepositPercent(appointmentDepositAmount, appointment.price);
+    const appointmentDepositPercent = inferDepositPercent(
+      appointmentDepositAmount,
+      appointment.price,
+      DEPOSIT_PERCENT_OPTIONS,
+    );
     const appointmentClient = {
       id: appointment.clientId,
       name: appointment.clientName || 'Cliente',
@@ -820,10 +764,10 @@ const AgendaScreen = () => {
       startAt: new Date(appointment.startAt),
       depositPercent: appointmentDepositPercent,
       depositAmount: appointmentDepositAmount,
-      depositAmountInput: formatCurrencyInput(appointmentDepositAmount),
       depositMode: appointmentDepositPercent === null ? 'manual' : 'percent',
       notes: appointment.notes || '',
     });
+    setDepositSyncToken((token) => token + 1);
 
     setModalVisible(true);
   };
@@ -907,41 +851,30 @@ const AgendaScreen = () => {
   ]);
 
   const handleDepositPercentPress = (percent) => {
-    const nextDepositAmount = calculateDepositAmount(selectedServicesTotal.price, percent);
-
     setForm((prev) => ({
       ...prev,
       depositPercent: percent,
-      depositAmount: nextDepositAmount,
-      depositAmountInput: formatCurrencyInput(nextDepositAmount),
+      depositAmount: calculateDepositAmount(selectedServicesTotal.price, percent),
       depositMode: 'percent',
     }));
+    setDepositSyncToken((token) => token + 1);
   };
 
-  const handleDepositAmountChange = (value) => {
-    const sanitizedValue = sanitizeCurrencyInput(value);
-    const parsedDepositAmount = parseCurrencyInput(sanitizedValue);
-
+  // O texto e a posicao do cursor ficam com o useCurrencyInput; aqui so entra o numero.
+  const handleDepositAmountChange = useCallback((amount) => {
     setForm((prev) => ({
       ...prev,
       depositPercent: null,
-      depositAmount: parsedDepositAmount ?? 0,
-      depositAmountInput: sanitizedValue,
+      depositAmount: amount,
       depositMode: 'manual',
     }));
-  };
+  }, []);
 
-  const handleDepositAmountBlur = () => {
-    const parsedDepositAmount = parseCurrencyInput(form.depositAmountInput);
-    const nextDepositAmount = Math.max(parsedDepositAmount ?? 0, 0);
-
-    setForm((prev) => ({
-      ...prev,
-      depositAmount: nextDepositAmount,
-      depositAmountInput: formatCurrencyInput(nextDepositAmount),
-      depositMode: 'manual',
-    }));
-  };
+  const depositInput = useCurrencyInput({
+    value: form.depositAmount,
+    syncToken: depositSyncToken,
+    onChangeValue: handleDepositAmountChange,
+  });
 
   const hasLocalAppointmentConflict = () => {
     if (!form.startAt || selectedServicesTotal.estimatedTime <= 0) {
@@ -981,10 +914,9 @@ const AgendaScreen = () => {
       return;
     }
 
-    const parsedDepositAmount = parseCurrencyInput(form.depositAmountInput);
-    const finalDepositAmount = parsedDepositAmount === null ? null : roundCurrency(parsedDepositAmount);
+    const finalDepositAmount = roundCurrency(Number(form.depositAmount || 0));
 
-    if (finalDepositAmount === null || !Number.isFinite(finalDepositAmount) || finalDepositAmount < 0) {
+    if (!Number.isFinite(finalDepositAmount) || finalDepositAmount < 0) {
       Alert.alert('Sinal inválido', 'Informe um valor de sinal válido.');
       return;
     }
@@ -1752,11 +1684,13 @@ const AgendaScreen = () => {
                   <Text style={styles.depositInputPrefix}>R$</Text>
                   <TextInput
                     style={styles.depositInput}
-                    value={form.depositAmountInput}
-                    onChangeText={handleDepositAmountChange}
-                    onBlur={handleDepositAmountBlur}
+                    {...depositInput}
                     keyboardType="decimal-pad"
                     placeholder="0,00"
+                    autoCorrect={false}
+                    autoComplete="off"
+                    importantForAutofill="no"
+                    accessibilityLabel="Valor do sinal em reais"
                   />
                 </View>
                 <View style={styles.depositSummaryGrid}>

--- a/src/screens/calendar/AgendaScreen.jsx
+++ b/src/screens/calendar/AgendaScreen.jsx
@@ -4,11 +4,11 @@ import {
   Alert,
   Animated,
   BackHandler,
-  FlatList,
   LayoutAnimation,
   Platform,
   RefreshControl,
   ScrollView,
+  SectionList,
   StyleSheet,
   Text,
   TextInput,
@@ -31,6 +31,26 @@ import {
   isSameCurrencyAmount,
   roundCurrency,
 } from '../../utils/currency';
+import {
+  AGENDA_MAX_LOOKAHEAD_DAYS,
+  AGENDA_WINDOW_DAYS,
+  addLocalDays,
+  buildAgendaSections,
+  buildAgendaWindow,
+  buildCalendarGridUtcRange,
+  endOfLocalDay,
+  findSectionIndexByKey,
+  getLocalDateKey,
+  getMonthKey,
+  getNextAgendaWindowBlock,
+  isCanceledAppointment,
+  isDayPlaceholder,
+  isWithinWindow,
+  mergeAppointmentsById,
+  sortAppointments,
+  startOfLocalDay,
+  summarizeAgendaSections,
+} from './agendaWindow';
 import api from '../../services/api';
 import { isSessionExpiredError } from '../../services/sessionManager';
 import {
@@ -40,13 +60,11 @@ import {
   updateAppointmentStatus,
 } from '../../services/private/appointmentAPI';
 
-const SLOT_STEP_MINUTES = 30;
 const DAY_START_HOUR = 8;
-const DAY_END_HOUR = 19;
 const CLIENT_SEARCH_LIMIT = 30;
 const DEFAULT_DEPOSIT_PERCENT = 0;
 const DEPOSIT_PERCENT_OPTIONS = [0, 15, 30];
-const CALENDAR_LOOKAHEAD_DAYS = 90;
+const AGENDA_END_REACHED_THRESHOLD = 0.4;
 const ACTION_ANIMATION_DURATION = 180;
 const ACTION_POPOVER_MAX_WIDTH = 268;
 const ACTION_POPOVER_ESTIMATED_HEIGHT = 210;
@@ -68,8 +86,6 @@ const statusColors = {
   completed: colors.success,
 };
 
-const isCanceledAppointment = (appointment) => appointment.status === 'canceled';
-
 const googleSyncLabels = {
   pending: 'Google pendente',
   synced: 'Google sincronizado',
@@ -81,14 +97,6 @@ const googleSyncColors = {
   synced: colors.success,
   failed: colors.error,
 };
-
-const sortAppointments = (items) => [...items].sort(
-  (a, b) => new Date(a.startAt).getTime() - new Date(b.startAt).getTime(),
-);
-
-const filterNonCanceledAppointments = (items) => (
-  items.filter((item) => !isCanceledAppointment(item))
-);
 
 const getAppointmentServices = (appointment) => {
   if (Array.isArray(appointment.services) && appointment.services.length > 0) {
@@ -137,67 +145,6 @@ const getAppointmentServiceName = (appointment) => {
     .join(' + ');
 };
 
-const buildDayUtcRange = (date) => {
-  const from = new Date(date);
-  from.setHours(0, 0, 0, 0);
-
-  const to = new Date(date);
-  to.setHours(23, 59, 59, 999);
-
-  return {
-    from: from.toISOString(),
-    to: to.toISOString(),
-  };
-};
-
-const padDatePart = (value) => String(value).padStart(2, '0');
-
-const getLocalDateKey = (dateValue) => {
-  const date = new Date(dateValue);
-  return [
-    date.getFullYear(),
-    padDatePart(date.getMonth() + 1),
-    padDatePart(date.getDate()),
-  ].join('-');
-};
-
-const getMonthKey = (dateValue) => {
-  const date = new Date(dateValue);
-  return `${date.getFullYear()}-${padDatePart(date.getMonth() + 1)}`;
-};
-
-const buildCalendarGridUtcRange = (monthValue) => {
-  const month = new Date(monthValue);
-  const firstDay = new Date(month.getFullYear(), month.getMonth(), 1);
-  const from = new Date(firstDay);
-  from.setDate(firstDay.getDate() - firstDay.getDay());
-  from.setHours(0, 0, 0, 0);
-
-  const to = new Date(from);
-  to.setDate(from.getDate() + 41);
-  to.setHours(23, 59, 59, 999);
-
-  return { from: from.toISOString(), to: to.toISOString() };
-};
-
-const buildInitialAgendaUtcRange = () => {
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-
-  const from = new Date(today);
-  from.setDate(today.getDate() + 1);
-
-  const to = new Date(today);
-  to.setDate(today.getDate() + CALENDAR_LOOKAHEAD_DAYS);
-  to.setHours(23, 59, 59, 999);
-
-  return { from: from.toISOString(), to: to.toISOString() };
-};
-
-const isSameLocalDay = (firstDate, secondDate) => (
-  getLocalDateKey(firstDate) === getLocalDateKey(secondDate)
-);
-
 const calculateServicesTotal = (services) => services.reduce((totals, service) => ({
   price: totals.price + Number(service.price || 0),
   estimatedTime: totals.estimatedTime + Number(service.estimatedTime || 0),
@@ -208,6 +155,9 @@ const formatDateLabel = (date) => date.toLocaleDateString('pt-BR', {
   day: '2-digit',
   month: 'long',
 });
+
+// "quinta-feira, 13 de agosto" fica longo demais no cabecalho da secao.
+const formatSectionDate = (date) => formatDateLabel(date).replace('-feira', '');
 
 const formatShortDate = (date) => date.toLocaleDateString('pt-BR', {
   day: '2-digit',
@@ -230,22 +180,6 @@ const isAppointmentConflictError = (error) => error?.response?.status === 409;
 
 const hasTimeOverlap = (startA, endA, startB, endB) => startA < endB && endA > startB;
 
-const createBaseSlots = (date) => {
-  const slots = [];
-  const cursor = new Date(date);
-  cursor.setHours(DAY_START_HOUR, 0, 0, 0);
-
-  const end = new Date(date);
-  end.setHours(DAY_END_HOUR, 0, 0, 0);
-
-  while (cursor < end) {
-    slots.push(new Date(cursor));
-    cursor.setMinutes(cursor.getMinutes() + SLOT_STEP_MINUTES);
-  }
-
-  return slots;
-};
-
 const AgendaScreen = () => {
   const navigation = useNavigation();
   const insets = useSafeAreaInsets();
@@ -253,7 +187,14 @@ const AgendaScreen = () => {
   const bottomInset = Math.max(insets.bottom, 8);
   const screenRef = useRef(null);
   const actionButtonRefs = useRef({});
-  const [selectedDate, setSelectedDate] = useState(new Date());
+  const sectionListRef = useRef(null);
+  const sectionsRef = useRef([]);
+  const scrollTargetRef = useRef(null);
+  const canLoadMoreRef = useRef(false);
+  // "Hoje" fica congelado na montagem para os rotulos nao mudarem sozinhos
+  // se o app ficar aberto durante a virada do dia.
+  const todayRef = useRef(startOfLocalDay(new Date()));
+  const [selectedDate, setSelectedDate] = useState(() => startOfLocalDay(new Date()));
   const [showDayPicker, setShowDayPicker] = useState(false);
   const [visibleCalendarMonth, setVisibleCalendarMonth] = useState(() => {
     const today = new Date();
@@ -263,8 +204,15 @@ const AgendaScreen = () => {
   const calendarMarksCacheRef = useRef({});
   const calendarCacheGenerationRef = useRef(0);
   const calendarRequestIdsRef = useRef({});
-  const didBootstrapRef = useRef(false);
-  const skipSelectedDateEffectRef = useRef(false);
+
+  const [agendaWindow, setAgendaWindow] = useState(() => {
+    const window = buildAgendaWindow(startOfLocalDay(new Date()));
+    return { start: window.start, end: window.end };
+  });
+  // Espelha a janela para os handlers assincronos nao lerem closure velha.
+  const windowRangeRef = useRef(agendaWindow);
+  const [loadMoreState, setLoadMoreState] = useState('idle');
+  const [scrollRequestId, setScrollRequestId] = useState(0);
 
   const [appointments, setAppointments] = useState([]);
   const [clients, setClients] = useState([]);
@@ -417,19 +365,25 @@ const AgendaScreen = () => {
     [appointments],
   );
 
-  const freeSlotsCount = useMemo(() => {
-    const baseSlots = createBaseSlots(selectedDate);
+  const sections = useMemo(() => buildAgendaSections({
+    appointments,
+    windowStart: agendaWindow.start,
+    windowEnd: agendaWindow.end,
+    referenceDate: todayRef.current,
+    focusedDate: selectedDate,
+  }), [appointments, agendaWindow, selectedDate]);
 
-    return baseSlots.filter((slot) => !activeAppointments.some((appointment) => {
-      const startAt = new Date(appointment.startAt);
-      const endAt = new Date(appointment.endAt);
-      return slot >= startAt && slot < endAt;
-    })).length;
-  }, [activeAppointments, selectedDate]);
+  const windowSummary = useMemo(() => summarizeAgendaSections(sections), [sections]);
 
-  const totalForecast = useMemo(
-    () => activeAppointments.reduce((sum, item) => sum + Number(item.price || 0), 0),
-    [activeAppointments],
+  // O retry de scroll roda dentro de setTimeout, entao precisa das secoes por ref.
+  useEffect(() => {
+    sectionsRef.current = sections;
+  }, [sections]);
+
+  const isWindowShowingToday = isWithinWindow(
+    todayRef.current,
+    agendaWindow.start,
+    agendaWindow.end,
   );
 
   const loadClientAvailability = async () => {
@@ -500,15 +454,32 @@ const AgendaScreen = () => {
     setServices(servicesResponse.data || []);
   };
 
-  const loadAgendaForDate = async (date, { isRefresh = false } = {}) => {
+  const applyWindowRange = (start, end) => {
+    windowRangeRef.current = { start, end };
+    setAgendaWindow({ start, end });
+  };
+
+  // Recarrega a janela inteira ancorada em uma data. Usado no bootstrap, no
+  // refresh e quando o seletor pede um dia longe do que esta carregado.
+  const loadAgendaWindow = async (anchorDate, { isRefresh = false, keepRange = false } = {}) => {
     if (!isRefresh) {
       setLoading(true);
     }
 
     try {
-      const { from, to } = buildDayUtcRange(date);
-      const data = await listAppointments({ from, to });
+      const range = keepRange
+        ? {
+          start: windowRangeRef.current.start,
+          end: windowRangeRef.current.end,
+          from: windowRangeRef.current.start.toISOString(),
+          to: windowRangeRef.current.end.toISOString(),
+        }
+        : buildAgendaWindow(anchorDate);
+
+      const data = await listAppointments({ from: range.from, to: range.to });
+      applyWindowRange(range.start, range.end);
       setAppointments(sortAppointments(data));
+      setLoadMoreState('idle');
     } catch (error) {
       console.error('Erro ao carregar agenda:', error.response?.data || error.message);
       if (!isSessionExpiredError(error)) {
@@ -519,6 +490,77 @@ const AgendaScreen = () => {
       setRefreshing(false);
     }
   };
+
+  const getMaxAgendaEnd = () => endOfLocalDay(
+    addLocalDays(todayRef.current, AGENDA_MAX_LOOKAHEAD_DAYS),
+  );
+
+  // Anexa blocos contiguos ate cobrir `desiredEnd`, sem recarregar o que ja veio.
+  const extendAgendaWindowTo = async (desiredEnd) => {
+    const maxEnd = getMaxAgendaEnd();
+    const limit = desiredEnd.getTime() > maxEnd.getTime() ? maxEnd : desiredEnd;
+
+    if (windowRangeRef.current.end.getTime() >= limit.getTime()) {
+      setLoadMoreState(
+        windowRangeRef.current.end.getTime() >= maxEnd.getTime() ? 'exhausted' : 'idle',
+      );
+      return;
+    }
+
+    setLoadMoreState('loading');
+
+    try {
+      let cursor = windowRangeRef.current.end;
+
+      while (cursor.getTime() < limit.getTime()) {
+        const block = getNextAgendaWindowBlock(cursor, limit);
+        if (!block) break;
+
+        // eslint-disable-next-line no-await-in-loop
+        const data = await listAppointments({ from: block.from, to: block.to });
+        setAppointments((previous) => sortAppointments(mergeAppointmentsById(previous, data)));
+        applyWindowRange(windowRangeRef.current.start, block.end);
+        cursor = block.end;
+      }
+
+      setLoadMoreState(
+        windowRangeRef.current.end.getTime() >= maxEnd.getTime() ? 'exhausted' : 'idle',
+      );
+    } catch (error) {
+      console.error('Erro ao carregar mais dias:', error.response?.data || error.message);
+      setLoadMoreState('error');
+    }
+  };
+
+  const extendAgendaWindow = () => extendAgendaWindowTo(
+    endOfLocalDay(addLocalDays(windowRangeRef.current.end, AGENDA_WINDOW_DAYS)),
+  );
+
+  // Garante que a data esteja na janela: estende quando esta logo adiante,
+  // reancora quando esta no passado ou muito longe.
+  const ensureDateVisible = async (date) => {
+    const target = startOfLocalDay(date);
+    const { start, end } = windowRangeRef.current;
+
+    if (isWithinWindow(target, start, end)) {
+      return;
+    }
+
+    const oneBlockAhead = endOfLocalDay(addLocalDays(end, AGENDA_WINDOW_DAYS));
+
+    if (target.getTime() > end.getTime() && target.getTime() <= oneBlockAhead.getTime()) {
+      await extendAgendaWindowTo(endOfLocalDay(addLocalDays(target, AGENDA_WINDOW_DAYS)));
+      return;
+    }
+
+    await loadAgendaWindow(target);
+  };
+
+  const isWithinLoadedWindow = (dateValue) => isWithinWindow(
+    dateValue,
+    windowRangeRef.current.start,
+    windowRangeRef.current.end,
+  );
 
   const loadCalendarMarks = useCallback(async (monthValue, { force = false } = {}) => {
     const normalizedMonth = new Date(
@@ -589,36 +631,79 @@ const AgendaScreen = () => {
     loadCalendarMarks(nextMonth);
   };
 
+  const requestScrollToDate = (date) => {
+    scrollTargetRef.current = { key: getLocalDateKey(date), attempts: 0 };
+    setScrollRequestId((id) => id + 1);
+  };
+
+  const focusDate = async (date) => {
+    const target = startOfLocalDay(date);
+    closeAppointmentActions();
+    setSelectedDate(target);
+    setVisibleCalendarMonth(new Date(target.getFullYear(), target.getMonth(), 1));
+    await ensureDateVisible(target);
+    requestScrollToDate(target);
+  };
+
+  const handlePickDate = (pickedDate) => {
+    setShowDayPicker(false);
+    focusDate(pickedDate);
+  };
+
+  const handleBackToToday = () => focusDate(todayRef.current);
+
+  const handleEndReached = () => {
+    if (!canLoadMoreRef.current || loadMoreState !== 'idle') {
+      return;
+    }
+    // Sem essa guarda, uma agenda curta dispara onEndReached ja na montagem e
+    // encadeia requisicoes ate o teto de lookahead.
+    canLoadMoreRef.current = false;
+    extendAgendaWindow();
+  };
+
+  // Sem getItemLayout (os cards tem altura variavel) o scroll para um indice ainda
+  // nao renderizado falha; aqui aproximamos e tentamos de novo, no maximo 3 vezes.
+  const handleScrollToIndexFailed = (info) => {
+    const target = scrollTargetRef.current;
+
+    if (!target || target.attempts >= 3) {
+      scrollTargetRef.current = null;
+      return;
+    }
+
+    target.attempts += 1;
+    sectionListRef.current?.getScrollResponder()?.scrollTo({
+      y: Math.max(0, (info.averageItemLength || 96) * info.index),
+      animated: false,
+    });
+
+    setTimeout(() => {
+      const sectionIndex = findSectionIndexByKey(sectionsRef.current, target.key);
+      if (sectionIndex >= 0) {
+        sectionListRef.current?.scrollToLocation({
+          sectionIndex,
+          itemIndex: 0,
+          viewPosition: 0,
+          animated: false,
+        });
+      }
+    }, 120);
+  };
+
   useEffect(() => {
     const bootstrap = async () => {
-      const today = new Date();
-      today.setHours(0, 0, 0, 0);
-      let initialDate = today;
-
-      try {
-        const { from, to } = buildInitialAgendaUtcRange();
-        const futureAppointments = filterNonCanceledAppointments(
-          await listAppointments({ from, to }),
-        );
-        const nextAppointment = sortAppointments(futureAppointments)[0];
-
-        if (nextAppointment) {
-          initialDate = new Date(nextAppointment.startAt);
-        }
-      } catch (error) {
-        console.error('Erro ao localizar próximo atendimento:', error.response?.data || error.message);
-      }
-
-      const initialMonth = new Date(initialDate.getFullYear(), initialDate.getMonth(), 1);
-      didBootstrapRef.current = true;
-      skipSelectedDateEffectRef.current = true;
-      setSelectedDate(initialDate);
+      // A agenda sempre abre em hoje: a janela de 30 dias ja traz os proximos
+      // atendimentos, entao nao existe mais o pulo para o proximo dia ocupado.
+      const today = todayRef.current;
+      const initialMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+      setSelectedDate(today);
       setVisibleCalendarMonth(initialMonth);
 
       try {
         await Promise.all([
           loadClientsAndServices(),
-          loadAgendaForDate(initialDate),
+          loadAgendaWindow(today),
           loadCalendarMarks(initialMonth),
         ]);
       } catch (error) {
@@ -633,21 +718,33 @@ const AgendaScreen = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Rola ate a secao pedida. Depende de `sections` porque a secao pode so
+  // existir depois que a janela terminar de carregar.
   useEffect(() => {
-    if (!didBootstrapRef.current) {
+    const target = scrollTargetRef.current;
+
+    // `consumed` evita que qualquer mudanca posterior em `sections` (troca de
+    // status, carregar mais dias) role a lista de volta para o alvo antigo.
+    if (!target || target.consumed || sections.length === 0) {
       return;
     }
 
-    if (skipSelectedDateEffectRef.current) {
-      skipSelectedDateEffectRef.current = false;
+    const sectionIndex = findSectionIndexByKey(sections, target.key);
+
+    if (sectionIndex < 0) {
       return;
     }
 
-    animateNextLayout();
-    closeAppointmentActions();
-    loadAgendaForDate(selectedDate);
+    target.consumed = true;
+    sectionListRef.current?.scrollToLocation({
+      sectionIndex,
+      itemIndex: 0,
+      viewPosition: 0,
+      viewOffset: 0,
+      animated: !reduceMotionEnabled,
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedDate]);
+  }, [scrollRequestId, sections]);
 
   useEffect(() => {
     if (!modalVisible) {
@@ -688,7 +785,7 @@ const AgendaScreen = () => {
     try {
       await Promise.all([
         loadClientsAndServices(),
-        loadAgendaForDate(selectedDate, { isRefresh: true }),
+        loadAgendaWindow(selectedDate, { isRefresh: true, keepRange: true }),
         loadCalendarMarks(visibleCalendarMonth, { force: true }),
       ]);
     } catch (error) {
@@ -955,12 +1052,13 @@ const AgendaScreen = () => {
             String(item.id) !== String(editingAppointmentId)
           ));
 
-          return isSameLocalDay(updated.startAt, selectedDate)
+          return isWithinLoadedWindow(updated.startAt)
             ? sortAppointments([...withoutEditedAppointment, updated])
             : sortAppointments(withoutEditedAppointment);
         });
         closeModal();
         refreshCalendarMarksForDates([previousAppointment?.startAt, updated.startAt]);
+        focusDate(new Date(updated.startAt));
       } catch (error) {
         if (!allowConflict && isAppointmentConflictError(error)) {
           showAppointmentConflictFeedback();
@@ -977,11 +1075,13 @@ const AgendaScreen = () => {
 
     try {
       const created = await createAppointment(payload);
-      if (isSameLocalDay(created.startAt, selectedDate)) {
+      if (isWithinLoadedWindow(created.startAt)) {
         setAppointments((prev) => sortAppointments([...prev, created]));
       }
       closeModal();
       refreshCalendarMarksForDates([created.startAt]);
+      // Leva a usuaria ate o dia salvo, mesmo que ele esteja fora da janela atual.
+      focusDate(new Date(created.startAt));
     } catch (error) {
       if (!allowConflict && isAppointmentConflictError(error)) {
         showAppointmentConflictFeedback();
@@ -1288,7 +1388,33 @@ const AgendaScreen = () => {
     );
   };
 
+  const renderSectionHeader = ({ section }) => (
+    <View style={styles.sectionHeader}>
+      <View style={styles.sectionHeaderTitleRow}>
+        {section.relativeLabel && (
+          <View style={styles.sectionBadge}>
+            <Text style={styles.sectionBadgeText}>{section.relativeLabel}</Text>
+          </View>
+        )}
+        <Text style={styles.sectionTitle} numberOfLines={1}>
+          {formatSectionDate(section.date)}
+        </Text>
+      </View>
+      <Text style={styles.sectionMeta}>
+        {section.activeCount === 1 ? '1 atendimento' : `${section.activeCount} atendimentos`}
+      </Text>
+    </View>
+  );
+
   const renderAppointmentItem = ({ item }) => {
+    if (isDayPlaceholder(item)) {
+      return (
+        <View style={styles.emptyDayRow}>
+          <Text style={styles.emptyDayText}>Nenhum atendimento</Text>
+        </View>
+      );
+    }
+
     const isExpanded = String(expandedAppointmentId) === String(item.id);
     const isAnimatingStatus = String(statusAnimationAppointmentId) === String(item.id);
     const isCanceled = isCanceledAppointment(item);
@@ -1396,7 +1522,7 @@ const AgendaScreen = () => {
   const renderEmptyAgenda = () => (
     <View style={styles.emptyState}>
       <Ionicons name="calendar-clear-outline" size={64} color={colors.lightGray} />
-      <Text style={styles.emptyTitle}>Nenhum agendamento neste dia</Text>
+      <Text style={styles.emptyTitle}>Nenhum agendamento no período</Text>
       <Text style={styles.emptySubtitle}>Crie seu primeiro agendamento em poucos toques.</Text>
 
       {!canSchedule && (
@@ -1414,6 +1540,23 @@ const AgendaScreen = () => {
             <Text style={styles.emptyActionText}>Cadastrar Serviço</Text>
           </TouchableOpacity>
         </View>
+      )}
+    </View>
+  );
+
+  const renderAgendaFooter = () => (
+    <View>
+      {windowSummary.appointments === 0 && renderEmptyAgenda()}
+      {loadMoreState === 'loading' && (
+        <Text style={styles.footerText}>Carregando mais dias...</Text>
+      )}
+      {loadMoreState === 'error' && (
+        <TouchableOpacity style={styles.footerButton} onPress={extendAgendaWindow}>
+          <Text style={styles.footerButtonText}>Não deu para carregar. Tentar novamente</Text>
+        </TouchableOpacity>
+      )}
+      {loadMoreState === 'exhausted' && (
+        <Text style={styles.footerText}>Você chegou ao fim dos próximos 12 meses.</Text>
       )}
     </View>
   );
@@ -1487,10 +1630,17 @@ const AgendaScreen = () => {
     <View ref={screenRef} style={styles.container}>
       <View style={styles.headerRow}>
         <Text style={styles.title}>Agenda</Text>
-        <TouchableOpacity style={styles.dayButton} onPress={openDayPicker}>
-          <Ionicons name="calendar-outline" size={18} color={colors.primary} />
-          <Text style={styles.dayButtonText}>{formatDateLabel(selectedDate)}</Text>
-        </TouchableOpacity>
+        <View style={styles.headerActions}>
+          {!isWindowShowingToday && (
+            <TouchableOpacity style={styles.todayButton} onPress={handleBackToToday}>
+              <Text style={styles.todayButtonText}>Hoje</Text>
+            </TouchableOpacity>
+          )}
+          <TouchableOpacity style={styles.dayButton} onPress={openDayPicker}>
+            <Ionicons name="calendar-outline" size={18} color={colors.primary} />
+            <Text style={styles.dayButtonText}>{formatDateLabel(selectedDate)}</Text>
+          </TouchableOpacity>
+        </View>
       </View>
 
       <DateTimePickerModal
@@ -1503,40 +1653,54 @@ const AgendaScreen = () => {
         markedDates={markedDates}
         onVisibleMonthChange={handleVisibleMonthChange}
         onCancel={() => setShowDayPicker(false)}
-        onConfirm={(pickedDate) => {
-          setShowDayPicker(false);
-          setVisibleCalendarMonth(new Date(pickedDate.getFullYear(), pickedDate.getMonth(), 1));
-          setSelectedDate(pickedDate);
-        }}
+        onConfirm={handlePickDate}
       />
 
       <View style={styles.summaryCard}>
-        <View>
-          <Text style={styles.summaryLabel}>Atendimentos</Text>
-          <Text style={styles.summaryValue}>{activeAppointments.length}</Text>
+        <View style={styles.summaryRow}>
+          <View>
+            <Text style={styles.summaryLabel}>Atendimentos</Text>
+            <Text style={styles.summaryValue}>{windowSummary.appointments}</Text>
+          </View>
+          <View>
+            <Text style={styles.summaryLabel}>Previsto</Text>
+            <Text style={styles.summaryValue}>{formatCurrency(windowSummary.forecast)}</Text>
+          </View>
+          <View>
+            <Text style={styles.summaryLabel}>Dias ocupados</Text>
+            <Text style={styles.summaryValue}>{windowSummary.busyDays}</Text>
+          </View>
         </View>
-        <View>
-          <Text style={styles.summaryLabel}>Previsto</Text>
-          <Text style={styles.summaryValue}>{formatCurrency(totalForecast)}</Text>
-        </View>
-        <View>
-          <Text style={styles.summaryLabel}>Livres</Text>
-          <Text style={styles.summaryValue}>{freeSlotsCount}</Text>
-        </View>
+        <Text style={styles.summaryPeriod}>
+          {formatShortDate(agendaWindow.start)} a {formatShortDate(agendaWindow.end)}
+        </Text>
       </View>
 
-      <FlatList
+      <SectionList
+        ref={sectionListRef}
         style={styles.list}
-        data={appointments}
-        keyExtractor={(item) => String(item.id)}
+        sections={sections}
+        keyExtractor={(item) => (
+          isDayPlaceholder(item) ? `empty-${item.dateKey}` : String(item.id)
+        )}
         renderItem={renderAppointmentItem}
-        ListEmptyComponent={renderEmptyAgenda}
+        renderSectionHeader={renderSectionHeader}
+        stickySectionHeadersEnabled
+        extraData={`${expandedAppointmentId}-${statusAnimationAppointmentId}`}
         contentContainerStyle={[
           styles.listContainer,
-          appointments.length === 0 && styles.emptyListContainer,
           { paddingBottom: 96 + bottomInset },
         ]}
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+        onEndReachedThreshold={AGENDA_END_REACHED_THRESHOLD}
+        onMomentumScrollBegin={() => { canLoadMoreRef.current = true; }}
+        onEndReached={handleEndReached}
+        onScrollToIndexFailed={handleScrollToIndexFailed}
+        onScrollBeginDrag={closeAppointmentActions}
+        ListFooterComponent={renderAgendaFooter}
+        initialNumToRender={12}
+        maxToRenderPerBatch={10}
+        windowSize={10}
         alwaysBounceVertical
       />
 
@@ -1809,6 +1973,24 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     color: colors.text,
   },
+  headerActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    flexShrink: 1,
+  },
+  todayButton: {
+    borderWidth: 1,
+    borderColor: colors.primary,
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  todayButtonText: {
+    color: colors.primary,
+    fontSize: 13,
+    fontWeight: '700',
+  },
   dayButton: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -1819,12 +2001,13 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     paddingVertical: 8,
     gap: 6,
-    maxWidth: '70%',
+    flexShrink: 1,
   },
   dayButtonText: {
     color: colors.text,
     textTransform: 'capitalize',
     fontSize: 13,
+    flexShrink: 1,
   },
   summaryCard: {
     backgroundColor: colors.white,
@@ -1832,9 +2015,91 @@ const styles = StyleSheet.create({
     borderColor: colors.border,
     borderRadius: 12,
     padding: 14,
+    marginBottom: 14,
+  },
+  summaryRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    marginBottom: 14,
+  },
+  summaryPeriod: {
+    marginTop: 10,
+    color: colors.darkGray,
+    fontSize: 11,
+  },
+  sectionHeader: {
+    // Precisa ser opaco: o cabecalho fica grudado no topo enquanto a lista rola.
+    backgroundColor: colors.background,
+    paddingTop: 6,
+    paddingBottom: 8,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 8,
+  },
+  sectionHeaderTitleRow: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    minWidth: 0,
+  },
+  sectionBadge: {
+    backgroundColor: colors.primary,
+    borderRadius: 999,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+  },
+  sectionBadgeText: {
+    color: colors.white,
+    fontSize: 10,
+    fontWeight: '800',
+    letterSpacing: 0.4,
+  },
+  sectionTitle: {
+    flexShrink: 1,
+    color: colors.text,
+    fontSize: 13,
+    fontWeight: '700',
+    textTransform: 'capitalize',
+  },
+  sectionMeta: {
+    color: colors.darkGray,
+    fontSize: 11,
+    flexShrink: 0,
+  },
+  emptyDayRow: {
+    paddingVertical: 10,
+    paddingHorizontal: 11,
+    marginBottom: 9,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderStyle: 'dashed',
+    borderColor: colors.border,
+    backgroundColor: colors.inputBackground,
+  },
+  emptyDayText: {
+    color: colors.darkGray,
+    fontSize: 13,
+  },
+  footerText: {
+    marginTop: 8,
+    textAlign: 'center',
+    color: colors.darkGray,
+    fontSize: 12,
+  },
+  footerButton: {
+    marginTop: 8,
+    alignSelf: 'center',
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+  },
+  footerButtonText: {
+    color: colors.primary,
+    fontSize: 13,
+    fontWeight: '700',
   },
   summaryLabel: {
     color: colors.darkGray,
@@ -1851,9 +2116,6 @@ const styles = StyleSheet.create({
   },
   list: {
     flex: 1,
-  },
-  emptyListContainer: {
-    flexGrow: 1,
   },
   card: {
     backgroundColor: colors.white,

--- a/src/screens/calendar/__tests__/agendaWindow.test.js
+++ b/src/screens/calendar/__tests__/agendaWindow.test.js
@@ -1,0 +1,218 @@
+import {
+  AGENDA_WINDOW_DAYS,
+  addLocalDays,
+  buildAgendaSections,
+  buildAgendaWindow,
+  endOfLocalDay,
+  findSectionIndexByKey,
+  getLocalDateKey,
+  getNextAgendaWindowBlock,
+  getRelativeDayLabel,
+  isDayPlaceholder,
+  isWithinWindow,
+  mergeAppointmentsById,
+  startOfLocalDay,
+  summarizeAgendaSections,
+} from '../agendaWindow';
+
+const TODAY = new Date(2026, 7, 11, 15, 30);
+
+const atLocalTime = (dayOffset, hour) => {
+  const date = addLocalDays(startOfLocalDay(TODAY), dayOffset);
+  date.setHours(hour, 0, 0, 0);
+  return date;
+};
+
+const buildAppointment = ({ id, dayOffset, hour = 9, status = 'scheduled', price = 100 }) => {
+  const startAt = atLocalTime(dayOffset, hour);
+  const endAt = new Date(startAt.getTime() + 60 * 60 * 1000);
+  return { id, startAt: startAt.toISOString(), endAt: endAt.toISOString(), status, price };
+};
+
+const sectionsFor = (appointments, focusedDate = null) => {
+  const window = buildAgendaWindow(TODAY);
+  return buildAgendaSections({
+    appointments,
+    windowStart: window.start,
+    windowEnd: window.end,
+    referenceDate: TODAY,
+    focusedDate,
+  });
+};
+
+describe('janela da agenda', () => {
+  it('comeca hoje a meia-noite e termina 30 dias depois', () => {
+    const window = buildAgendaWindow(TODAY);
+
+    expect(getLocalDateKey(window.start)).toBe('2026-08-11');
+    expect(window.start.getHours()).toBe(0);
+    expect(window.start.getMinutes()).toBe(0);
+    expect(getLocalDateKey(window.end)).toBe('2026-09-10');
+    expect(window.end.getHours()).toBe(23);
+    expect(window.end.getMilliseconds()).toBe(999);
+  });
+
+  it('encadeia o bloco seguinte sem sobreposicao nem buraco', () => {
+    const window = buildAgendaWindow(TODAY);
+    const maxEnd = endOfLocalDay(addLocalDays(startOfLocalDay(TODAY), 365));
+    const block = getNextAgendaWindowBlock(window.end, maxEnd);
+
+    expect(getLocalDateKey(block.start)).toBe('2026-09-11');
+    expect(block.start.getHours()).toBe(0);
+    expect(getLocalDateKey(block.end)).toBe('2026-10-10');
+  });
+
+  it('corta o ultimo bloco no teto de lookahead', () => {
+    const window = buildAgendaWindow(TODAY);
+    const maxEnd = endOfLocalDay(addLocalDays(startOfLocalDay(TODAY), 35));
+    const block = getNextAgendaWindowBlock(window.end, maxEnd);
+
+    expect(getLocalDateKey(block.end)).toBe(getLocalDateKey(maxEnd));
+  });
+
+  it('devolve null quando a janela ja alcancou o teto', () => {
+    const maxEnd = endOfLocalDay(addLocalDays(startOfLocalDay(TODAY), 30));
+    const window = buildAgendaWindow(TODAY);
+
+    expect(getNextAgendaWindowBlock(window.end, maxEnd)).toBeNull();
+  });
+
+  it('reconhece datas dentro e fora da janela', () => {
+    const window = buildAgendaWindow(TODAY);
+
+    expect(isWithinWindow(atLocalTime(0, 9), window.start, window.end)).toBe(true);
+    expect(isWithinWindow(atLocalTime(AGENDA_WINDOW_DAYS, 23), window.start, window.end)).toBe(true);
+    expect(isWithinWindow(atLocalTime(-1, 9), window.start, window.end)).toBe(false);
+    expect(isWithinWindow(atLocalTime(31, 9), window.start, window.end)).toBe(false);
+  });
+
+  it('funde listas por id deixando a resposta mais nova vencer', () => {
+    const current = [buildAppointment({ id: 1, dayOffset: 0 })];
+    const next = [
+      { ...buildAppointment({ id: 1, dayOffset: 0 }), status: 'completed' },
+      buildAppointment({ id: 2, dayOffset: 1 }),
+    ];
+
+    const merged = mergeAppointmentsById(current, next);
+
+    expect(merged).toHaveLength(2);
+    expect(merged[0].status).toBe('completed');
+    expect(merged[1].id).toBe(2);
+  });
+});
+
+describe('secoes da agenda', () => {
+  it('nunca pula hoje, mesmo sem nenhum agendamento', () => {
+    const sections = sectionsFor([]);
+
+    expect(sections).toHaveLength(1);
+    expect(sections[0].key).toBe('2026-08-11');
+    expect(sections[0].relativeLabel).toBe('HOJE');
+    expect(sections[0].activeCount).toBe(0);
+    expect(isDayPlaceholder(sections[0].data[0])).toBe(true);
+  });
+
+  it('mostra hoje vazio antes do proximo dia com atendimento', () => {
+    // Regressao: o bootstrap pulava hoje e abria direto no proximo atendimento.
+    const sections = sectionsFor([buildAppointment({ id: 1, dayOffset: 3 })]);
+
+    expect(sections.map((section) => section.key)).toEqual(['2026-08-11', '2026-08-14']);
+    expect(sections[0].activeCount).toBe(0);
+    expect(sections[1].activeCount).toBe(1);
+  });
+
+  it('rotula hoje e amanha', () => {
+    const sections = sectionsFor([
+      buildAppointment({ id: 1, dayOffset: 0 }),
+      buildAppointment({ id: 2, dayOffset: 1 }),
+      buildAppointment({ id: 3, dayOffset: 5 }),
+    ]);
+
+    expect(sections.map((section) => section.relativeLabel)).toEqual(['HOJE', 'AMANHÃ', null]);
+  });
+
+  it('mantem o dia que so tem cancelado, mas sem contar', () => {
+    const sections = sectionsFor([
+      buildAppointment({ id: 1, dayOffset: 4, status: 'canceled' }),
+    ]);
+
+    const canceledSection = sections.find((section) => section.key === '2026-08-15');
+    expect(canceledSection.activeCount).toBe(0);
+    expect(canceledSection.forecast).toBe(0);
+    expect(canceledSection.data).toHaveLength(1);
+    expect(canceledSection.data[0].id).toBe(1);
+  });
+
+  it('ordena secoes e itens dentro da secao por horario', () => {
+    const sections = sectionsFor([
+      buildAppointment({ id: 1, dayOffset: 5, hour: 14 }),
+      buildAppointment({ id: 2, dayOffset: 2, hour: 16 }),
+      buildAppointment({ id: 3, dayOffset: 2, hour: 8 }),
+    ]);
+
+    expect(sections.map((section) => section.key)).toEqual(['2026-08-11', '2026-08-13', '2026-08-16']);
+    expect(sections[1].data.map((item) => item.id)).toEqual([3, 2]);
+  });
+
+  it('cria secao para o dia escolhido no seletor quando esta na janela', () => {
+    const sections = sectionsFor([], atLocalTime(6, 9));
+
+    expect(sections.map((section) => section.key)).toEqual(['2026-08-11', '2026-08-17']);
+  });
+
+  it('ignora o dia escolhido quando esta fora da janela', () => {
+    const sections = sectionsFor([], atLocalTime(90, 9));
+
+    expect(sections.map((section) => section.key)).toEqual(['2026-08-11']);
+  });
+
+  it('descarta agendamentos fora da janela carregada', () => {
+    const sections = sectionsFor([
+      buildAppointment({ id: 1, dayOffset: 2 }),
+      buildAppointment({ id: 2, dayOffset: 60 }),
+    ]);
+
+    expect(sections.map((section) => section.key)).toEqual(['2026-08-11', '2026-08-13']);
+  });
+});
+
+describe('resumo do periodo', () => {
+  it('soma so os ativos e conta os dias ocupados', () => {
+    const sections = sectionsFor([
+      buildAppointment({ id: 1, dayOffset: 0, price: 120 }),
+      buildAppointment({ id: 2, dayOffset: 0, hour: 14, price: 80 }),
+      buildAppointment({ id: 3, dayOffset: 2, price: 200, status: 'canceled' }),
+      buildAppointment({ id: 4, dayOffset: 4, price: 50, status: 'completed' }),
+    ]);
+
+    expect(summarizeAgendaSections(sections)).toEqual({
+      appointments: 3,
+      forecast: 250,
+      busyDays: 2,
+    });
+  });
+
+  it('devolve zeros quando nao ha nada ativo', () => {
+    expect(summarizeAgendaSections(sectionsFor([]))).toEqual({
+      appointments: 0,
+      forecast: 0,
+      busyDays: 0,
+    });
+  });
+});
+
+describe('navegacao entre secoes', () => {
+  it('acha o indice da secao pelo dia', () => {
+    const sections = sectionsFor([
+      buildAppointment({ id: 1, dayOffset: 2 }),
+      buildAppointment({ id: 2, dayOffset: 5 }),
+    ]);
+
+    expect(findSectionIndexByKey(sections, '2026-08-16')).toBe(2);
+    expect(findSectionIndexByKey(sections, '2026-08-20')).toBe(-1);
+  });
+
+  it('nao rotula dias distantes como hoje ou amanha', () => {
+    expect(getRelativeDayLabel(atLocalTime(2, 9), TODAY)).toBeNull();
+  });
+});

--- a/src/screens/calendar/agendaWindow.js
+++ b/src/screens/calendar/agendaWindow.js
@@ -1,0 +1,202 @@
+// Logica pura da Agenda multi-dia: janela deslizante de datas e agrupamento por dia.
+// Fica fora do AgendaScreen para poder ser testada sem React Native.
+
+export const AGENDA_WINDOW_DAYS = 30;
+export const AGENDA_MAX_LOOKAHEAD_DAYS = 365;
+
+const padDatePart = (value) => String(value).padStart(2, '0');
+
+export const startOfLocalDay = (value) => {
+  const date = new Date(value);
+  date.setHours(0, 0, 0, 0);
+  return date;
+};
+
+export const endOfLocalDay = (value) => {
+  const date = new Date(value);
+  date.setHours(23, 59, 59, 999);
+  return date;
+};
+
+export const addLocalDays = (value, days) => {
+  const date = new Date(value);
+  date.setDate(date.getDate() + days);
+  return date;
+};
+
+export const getLocalDateKey = (dateValue) => {
+  const date = new Date(dateValue);
+  return [
+    date.getFullYear(),
+    padDatePart(date.getMonth() + 1),
+    padDatePart(date.getDate()),
+  ].join('-');
+};
+
+export const getMonthKey = (dateValue) => {
+  const date = new Date(dateValue);
+  return `${date.getFullYear()}-${padDatePart(date.getMonth() + 1)}`;
+};
+
+export const isSameLocalDay = (firstDate, secondDate) => (
+  getLocalDateKey(firstDate) === getLocalDateKey(secondDate)
+);
+
+export const buildCalendarGridUtcRange = (monthValue) => {
+  const month = new Date(monthValue);
+  const firstDay = new Date(month.getFullYear(), month.getMonth(), 1);
+  const from = new Date(firstDay);
+  from.setDate(firstDay.getDate() - firstDay.getDay());
+  from.setHours(0, 0, 0, 0);
+
+  const to = new Date(from);
+  to.setDate(from.getDate() + 41);
+  to.setHours(23, 59, 59, 999);
+
+  return { from: from.toISOString(), to: to.toISOString() };
+};
+
+export const isCanceledAppointment = (appointment) => appointment.status === 'canceled';
+
+export const sortAppointments = (items) => [...items].sort(
+  (a, b) => new Date(a.startAt).getTime() - new Date(b.startAt).getTime(),
+);
+
+export const filterNonCanceledAppointments = (items) => (
+  items.filter((item) => !isCanceledAppointment(item))
+);
+
+export const buildAgendaWindow = (anchorDate, days = AGENDA_WINDOW_DAYS) => {
+  const start = startOfLocalDay(anchorDate);
+  const end = endOfLocalDay(addLocalDays(start, days));
+
+  return { start, end, from: start.toISOString(), to: end.toISOString() };
+};
+
+// Bloco seguinte, contiguo e sem sobreposicao com o que ja esta carregado.
+// Devolve null quando a janela ja alcancou o teto de lookahead.
+export const getNextAgendaWindowBlock = (currentEnd, maxEnd, days = AGENDA_WINDOW_DAYS) => {
+  const start = startOfLocalDay(addLocalDays(currentEnd, 1));
+  const limit = endOfLocalDay(maxEnd);
+
+  if (start.getTime() > limit.getTime()) {
+    return null;
+  }
+
+  const naturalEnd = endOfLocalDay(addLocalDays(start, days - 1));
+  const end = naturalEnd.getTime() > limit.getTime() ? limit : naturalEnd;
+
+  return { start, end, from: start.toISOString(), to: end.toISOString() };
+};
+
+export const isWithinWindow = (dateValue, start, end) => {
+  const time = new Date(dateValue).getTime();
+  return time >= new Date(start).getTime() && time <= new Date(end).getTime();
+};
+
+export const mergeAppointmentsById = (current, next) => {
+  const merged = [...current];
+  const indexById = new Map(current.map((item, index) => [String(item.id), index]));
+
+  next.forEach((item) => {
+    const index = indexById.get(String(item.id));
+
+    if (index === undefined) {
+      indexById.set(String(item.id), merged.length);
+      merged.push(item);
+      return;
+    }
+
+    // A resposta mais recente vence, para o refresh nao ficar com dado velho.
+    merged[index] = item;
+  });
+
+  return merged;
+};
+
+export const getRelativeDayLabel = (date, referenceDate) => {
+  if (isSameLocalDay(date, referenceDate)) {
+    return 'HOJE';
+  }
+
+  if (isSameLocalDay(date, addLocalDays(referenceDate, 1))) {
+    return 'AMANHÃ';
+  }
+
+  return null;
+};
+
+export const createEmptyDayPlaceholder = (dateKey) => ({ __placeholder: true, dateKey });
+
+export const isDayPlaceholder = (item) => Boolean(item && item.__placeholder);
+
+// Agrupa os agendamentos carregados em secoes de um dia cada.
+//
+// Vira secao: todo dia com algum agendamento, mais hoje e mais o dia escolhido
+// no seletor. Hoje entra sempre para nunca ser pulado, mesmo vazio.
+// Cancelados entram na secao (o guardrail exige que continuem restauraveis),
+// mas ficam de fora de todos os contadores.
+export const buildAgendaSections = ({
+  appointments = [],
+  windowStart,
+  windowEnd,
+  referenceDate = new Date(),
+  focusedDate = null,
+}) => {
+  const startKey = getLocalDateKey(windowStart);
+  const endKey = getLocalDateKey(windowEnd);
+  const buckets = new Map();
+
+  const ensureBucket = (dateValue) => {
+    const key = getLocalDateKey(dateValue);
+
+    if (key < startKey || key > endKey) {
+      return null;
+    }
+
+    if (!buckets.has(key)) {
+      buckets.set(key, { key, date: startOfLocalDay(dateValue), items: [] });
+    }
+
+    return buckets.get(key);
+  };
+
+  ensureBucket(referenceDate);
+
+  if (focusedDate) {
+    ensureBucket(focusedDate);
+  }
+
+  appointments.forEach((appointment) => {
+    const bucket = ensureBucket(appointment.startAt);
+    if (bucket) {
+      bucket.items.push(appointment);
+    }
+  });
+
+  return [...buckets.values()]
+    .sort((a, b) => (a.key < b.key ? -1 : 1))
+    .map((bucket) => {
+      const data = sortAppointments(bucket.items);
+      const active = filterNonCanceledAppointments(data);
+
+      return {
+        key: bucket.key,
+        date: bucket.date,
+        relativeLabel: getRelativeDayLabel(bucket.date, referenceDate),
+        activeCount: active.length,
+        forecast: active.reduce((total, item) => total + Number(item.price || 0), 0),
+        data: data.length > 0 ? data : [createEmptyDayPlaceholder(bucket.key)],
+      };
+    });
+};
+
+export const summarizeAgendaSections = (sections) => sections.reduce((totals, section) => ({
+  appointments: totals.appointments + section.activeCount,
+  forecast: totals.forecast + section.forecast,
+  busyDays: totals.busyDays + (section.activeCount > 0 ? 1 : 0),
+}), { appointments: 0, forecast: 0, busyDays: 0 });
+
+export const findSectionIndexByKey = (sections, dateKey) => (
+  sections.findIndex((section) => section.key === dateKey)
+);

--- a/src/utils/__tests__/currency.test.js
+++ b/src/utils/__tests__/currency.test.js
@@ -1,0 +1,177 @@
+import {
+  applyCurrencyInputChange,
+  calculateDepositAmount,
+  calculateRemainingAmount,
+  createCurrencyBufferFromAmount,
+  createEmptyCurrencyBuffer,
+  formatCurrencyBuffer,
+  getCurrencyBufferAmount,
+  getCurrencyBufferSelection,
+  inferDepositPercent,
+  isSameCurrencyAmount,
+  roundCurrency,
+} from '../currency';
+
+const DEPOSIT_PERCENT_OPTIONS = [0, 15, 30];
+
+// Reproduz o que o TextInput nativo faz: insere/remove no cursor e devolve o texto inteiro.
+const typeChar = (buffer, char) => {
+  const text = formatCurrencyBuffer(buffer);
+  const { start } = getCurrencyBufferSelection(buffer);
+  return applyCurrencyInputChange(buffer, text.slice(0, start) + char + text.slice(start));
+};
+
+const typeChars = (buffer, chars) => [...chars].reduce(typeChar, buffer);
+
+const backspace = (buffer) => {
+  const text = formatCurrencyBuffer(buffer);
+  const { start } = getCurrencyBufferSelection(buffer);
+  if (start === 0) return buffer;
+  return applyCurrencyInputChange(buffer, text.slice(0, start - 1) + text.slice(start));
+};
+
+const snapshot = (buffer) => ({
+  text: formatCurrencyBuffer(buffer),
+  cursor: getCurrencyBufferSelection(buffer).start,
+  amount: getCurrencyBufferAmount(buffer),
+});
+
+describe('buffer de moeda em tempo real', () => {
+  it('trata cada digito como real, nao como centavo', () => {
+    let buffer = createEmptyCurrencyBuffer();
+
+    buffer = typeChar(buffer, '9');
+    expect(snapshot(buffer)).toEqual({ text: '9,00', cursor: 1, amount: 9 });
+
+    buffer = typeChar(buffer, '0');
+    expect(snapshot(buffer)).toEqual({ text: '90,00', cursor: 2, amount: 90 });
+
+    buffer = typeChar(buffer, '0');
+    expect(snapshot(buffer)).toEqual({ text: '900,00', cursor: 3, amount: 900 });
+
+    buffer = typeChar(buffer, '0');
+    expect(snapshot(buffer)).toEqual({ text: '9.000,00', cursor: 5, amount: 9000 });
+  });
+
+  it('entra nos centavos pela virgula e mantem as duas casas visiveis', () => {
+    let buffer = typeChars(createEmptyCurrencyBuffer(), '9000');
+
+    buffer = typeChar(buffer, ',');
+    expect(snapshot(buffer)).toEqual({ text: '9.000,', cursor: 6, amount: 9000 });
+
+    buffer = typeChar(buffer, '5');
+    expect(snapshot(buffer)).toEqual({ text: '9.000,50', cursor: 7, amount: 9000.5 });
+
+    buffer = typeChar(buffer, '7');
+    expect(snapshot(buffer)).toEqual({ text: '9.000,57', cursor: 8, amount: 9000.57 });
+  });
+
+  it('desce a escada de volta no backspace', () => {
+    let buffer = typeChars(createEmptyCurrencyBuffer(), '9000,57');
+
+    buffer = backspace(buffer);
+    expect(snapshot(buffer)).toEqual({ text: '9.000,50', cursor: 7, amount: 9000.5 });
+
+    buffer = backspace(buffer);
+    expect(snapshot(buffer)).toEqual({ text: '9.000,', cursor: 6, amount: 9000 });
+
+    buffer = backspace(buffer);
+    expect(snapshot(buffer)).toEqual({ text: '9.000,00', cursor: 5, amount: 9000 });
+
+    buffer = backspace(buffer);
+    expect(snapshot(buffer)).toEqual({ text: '900,00', cursor: 3, amount: 900 });
+  });
+
+  it('nao deixa o valor pre-preenchido contaminar o que foi digitado', () => {
+    // Regressao: o campo abria com "0,00" e digitar 9 virava "0,009" = R$ 0,01.
+    const prefilled = createCurrencyBufferFromAmount(0);
+    expect(formatCurrencyBuffer(prefilled)).toBe('0,00');
+
+    const buffer = typeChar(createEmptyCurrencyBuffer(), '9');
+    expect(getCurrencyBufferAmount(buffer)).toBe(9);
+  });
+
+  it('digita por cima do zero inicial sem esvaziar o campo antes', () => {
+    const buffer = typeChar(createCurrencyBufferFromAmount(0), '9');
+    expect(snapshot(buffer)).toEqual({ text: '9,00', cursor: 1, amount: 9 });
+  });
+
+  it('aceita o ponto do teclado numerico como separador decimal', () => {
+    const buffer = typeChars(createEmptyCurrencyBuffer(), '90.5');
+    expect(snapshot(buffer)).toEqual({ text: '90,50', cursor: 4, amount: 90.5 });
+  });
+
+  it('sobrescreve a casa de centavo em vez de inserir', () => {
+    const buffer = createCurrencyBufferFromAmount(49.5);
+    // Cursor logo depois da virgula, sobre o primeiro centavo.
+    const next = applyCurrencyInputChange(buffer, '49,750');
+    expect(snapshot(next)).toEqual({ text: '49,70', cursor: 4, amount: 49.7 });
+  });
+
+  it('reparseia texto colado', () => {
+    const buffer = applyCurrencyInputChange(createEmptyCurrencyBuffer(), 'R$ 1.234,56');
+    expect(snapshot(buffer)).toEqual({ text: '1.234,56', cursor: 5, amount: 1234.56 });
+  });
+
+  it('respeita o teto de digitos da parte inteira', () => {
+    const buffer = typeChars(createEmptyCurrencyBuffer(), '1234567890123');
+    expect(getCurrencyBufferAmount(buffer)).toBe(123456789);
+  });
+
+  it('volta ao estado vazio quando tudo e apagado', () => {
+    let buffer = typeChar(createEmptyCurrencyBuffer(), '9');
+    buffer = backspace(buffer);
+    expect(buffer.isEmpty).toBe(true);
+    expect(formatCurrencyBuffer(buffer)).toBe('');
+    expect(getCurrencyBufferAmount(buffer)).toBe(0);
+  });
+
+  it('normaliza centavos incompletos ao sair do campo', () => {
+    const typed = typeChars(createEmptyCurrencyBuffer(), '90,');
+    expect(formatCurrencyBuffer(typed)).toBe('90,');
+
+    const blurred = createCurrencyBufferFromAmount(getCurrencyBufferAmount(typed));
+    expect(formatCurrencyBuffer(blurred)).toBe('90,00');
+  });
+
+  it('devolve 0,00 quando o campo vazio perde o foco', () => {
+    const blurred = createCurrencyBufferFromAmount(getCurrencyBufferAmount(createEmptyCurrencyBuffer()));
+    expect(formatCurrencyBuffer(blurred)).toBe('0,00');
+  });
+
+  it('ignora valores negativos vindos de fora', () => {
+    expect(formatCurrencyBuffer(createCurrencyBufferFromAmount(-50))).toBe('0,00');
+  });
+});
+
+describe('helpers de sinal', () => {
+  it('calcula o sinal por percentual', () => {
+    expect(calculateDepositAmount(330, 15)).toBe(49.5);
+    expect(calculateDepositAmount(330, 0)).toBe(0);
+  });
+
+  it('infere o chip a partir do valor salvo', () => {
+    expect(inferDepositPercent(49.5, 330, DEPOSIT_PERCENT_OPTIONS)).toBe(15);
+    expect(inferDepositPercent(99, 330, DEPOSIT_PERCENT_OPTIONS)).toBe(30);
+    expect(inferDepositPercent(50, 330, DEPOSIT_PERCENT_OPTIONS)).toBeNull();
+    expect(inferDepositPercent(0, 0, DEPOSIT_PERCENT_OPTIONS)).toBeNull();
+  });
+
+  it('nunca deixa o falta pagar negativo', () => {
+    expect(calculateRemainingAmount(330, 400)).toBe(0);
+    expect(calculateRemainingAmount(330, 49.5)).toBe(280.5);
+  });
+
+  it('compara valores com tolerancia de centavo', () => {
+    expect(isSameCurrencyAmount(49.5, 49.5)).toBe(true);
+    // A tolerancia e "menor que um centavo", entao 49,50 e 49,51 ainda contam como iguais.
+    // Serve so como guarda de idempotencia; a comparacao exata fica com roundCurrency.
+    expect(isSameCurrencyAmount(49.5, 49.51)).toBe(true);
+    expect(isSameCurrencyAmount(49.5, 49.52)).toBe(false);
+  });
+
+  it('arredonda para duas casas', () => {
+    expect(roundCurrency(1.005)).toBe(1.01);
+    expect(roundCurrency(0.1 + 0.2)).toBe(0.3);
+  });
+});

--- a/src/utils/currency.js
+++ b/src/utils/currency.js
@@ -1,0 +1,279 @@
+export const MAX_INT_DIGITS = 9;
+
+export const roundCurrency = (value = 0) => Math.round((Number(value || 0) + Number.EPSILON) * 100) / 100;
+
+export const formatCurrency = (value = 0) => Number(value || 0).toLocaleString('pt-BR', {
+  style: 'currency',
+  currency: 'BRL',
+});
+
+export const formatCurrencyInput = (value = 0) => roundCurrency(value).toLocaleString('pt-BR', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+export const sanitizeCurrencyInput = (value = '') => String(value).replace(/[^\d.,]/g, '');
+
+export const parseCurrencyInput = (value = '') => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? roundCurrency(value) : null;
+  }
+
+  const sanitizedValue = sanitizeCurrencyInput(value);
+  if (!sanitizedValue) {
+    return 0;
+  }
+
+  const lastComma = sanitizedValue.lastIndexOf(',');
+  const lastDot = sanitizedValue.lastIndexOf('.');
+  const normalizedValue = lastComma > lastDot
+    ? sanitizedValue.replace(/\./g, '').replace(',', '.')
+    : sanitizedValue.replace(/,/g, '');
+  const parsedValue = Number(normalizedValue);
+
+  return Number.isFinite(parsedValue) ? roundCurrency(parsedValue) : null;
+};
+
+export const isSameCurrencyAmount = (firstValue = 0, secondValue = 0) => (
+  Math.abs(roundCurrency(firstValue) - roundCurrency(secondValue)) < 0.01
+);
+
+export const calculateRemainingAmount = (price = 0, depositAmount = 0) => {
+  const total = Math.max(Number(price || 0), 0);
+  const deposit = Math.max(Number(depositAmount || 0), 0);
+  return roundCurrency(Math.max(total - deposit, 0));
+};
+
+export const calculateDepositAmount = (price = 0, percent = 0) => (
+  roundCurrency((Number(price || 0) * Number(percent || 0)) / 100)
+);
+
+export const inferDepositPercent = (depositAmount = 0, price = 0, percentOptions = []) => {
+  const numericPrice = Number(price || 0);
+  const numericDeposit = Number(depositAmount || 0);
+
+  if (!numericPrice || !Number.isFinite(numericPrice) || !Number.isFinite(numericDeposit)) {
+    return null;
+  }
+
+  return percentOptions.find((option) => (
+    isSameCurrencyAmount(calculateDepositAmount(numericPrice, option), numericDeposit)
+  )) ?? null;
+};
+
+// A partir daqui fica a maquina de estados do campo de moeda em tempo real.
+//
+// A fonte de verdade nao e o texto exibido, e sim um buffer de digitos. Isso permite
+// manter as duas casas decimais sempre visiveis e ainda assim tratar cada digito novo
+// como REAL, e nao como centavo: enquanto o usuario digita a parte inteira o cursor
+// fica ancorado imediatamente antes da virgula.
+
+const normalizeIntDigits = (value = '') => String(value).replace(/\D/g, '').replace(/^0+(?=\d)/, '');
+
+const groupIntDigits = (value = '') => (
+  (normalizeIntDigits(value) || '0').replace(/\B(?=(\d{3})+(?!\d))/g, '.')
+);
+
+const countDigits = (text = '') => (String(text).match(/\d/g) || []).length;
+
+const clampDecimalPosition = (position) => Math.min(Math.max(position, 0), 1);
+
+export const createEmptyCurrencyBuffer = () => ({
+  intDigits: '',
+  decDigits: '00',
+  mode: 'integer',
+  decCaret: 2,
+  isEmpty: true,
+});
+
+export const createCurrencyBufferFromAmount = (amount = 0) => {
+  const safeAmount = Math.max(roundCurrency(Number(amount) || 0), 0);
+  const [intPart, decPart] = safeAmount.toFixed(2).split('.');
+
+  return {
+    intDigits: normalizeIntDigits(intPart) || '0',
+    decDigits: decPart,
+    mode: 'integer',
+    decCaret: 2,
+    isEmpty: false,
+  };
+};
+
+export const formatCurrencyBuffer = (buffer) => {
+  if (buffer.isEmpty) {
+    return '';
+  }
+
+  const intText = groupIntDigits(buffer.intDigits);
+
+  // Estado transitorio logo depois de digitar a virgula, antes do primeiro centavo.
+  if (buffer.mode === 'decimal' && buffer.decCaret === 0 && buffer.decDigits === '00') {
+    return `${intText},`;
+  }
+
+  return `${intText},${buffer.decDigits}`;
+};
+
+export const getCurrencyBufferSelection = (buffer) => {
+  if (buffer.isEmpty) {
+    return { start: 0, end: 0 };
+  }
+
+  const commaIndex = formatCurrencyBuffer(buffer).indexOf(',');
+  const position = buffer.mode === 'decimal'
+    ? commaIndex + 1 + buffer.decCaret
+    : commaIndex;
+
+  return { start: position, end: position };
+};
+
+export const getCurrencyBufferAmount = (buffer) => (
+  buffer.isEmpty ? 0 : roundCurrency(Number(`${buffer.intDigits || '0'}.${buffer.decDigits}`))
+);
+
+// Menor diferenca entre o texto que renderizamos e o texto que voltou do nativo.
+// Trabalhar por diff evita depender da selecao reportada pelo TextInput, que diverge
+// entre iOS e Android, e ainda cobre o caso do usuario tocar no meio do numero.
+const diffText = (previous, next) => {
+  let start = 0;
+  while (start < previous.length && start < next.length && previous[start] === next[start]) {
+    start += 1;
+  }
+
+  let endPrevious = previous.length;
+  let endNext = next.length;
+  while (endPrevious > start && endNext > start && previous[endPrevious - 1] === next[endNext - 1]) {
+    endPrevious -= 1;
+    endNext -= 1;
+  }
+
+  return {
+    start,
+    removed: previous.slice(start, endPrevious),
+    inserted: next.slice(start, endNext),
+  };
+};
+
+const withIntDigits = (buffer, intDigits) => {
+  const nextIntDigits = normalizeIntDigits(intDigits).slice(0, MAX_INT_DIGITS);
+
+  if (nextIntDigits === '' && buffer.decDigits === '00') {
+    return createEmptyCurrencyBuffer();
+  }
+
+  return { ...buffer, intDigits: nextIntDigits, mode: 'integer' };
+};
+
+const applyInsertion = (buffer, previousText, start, inserted) => {
+  if (inserted === ',' || inserted === '.') {
+    return {
+      ...buffer,
+      isEmpty: false,
+      intDigits: buffer.isEmpty ? '0' : buffer.intDigits,
+      decDigits: '00',
+      mode: 'decimal',
+      decCaret: 0,
+    };
+  }
+
+  if (!/\d/.test(inserted)) {
+    return buffer;
+  }
+
+  if (buffer.isEmpty) {
+    return {
+      intDigits: inserted,
+      decDigits: '00',
+      mode: 'integer',
+      decCaret: 2,
+      isEmpty: false,
+    };
+  }
+
+  const commaIndex = previousText.indexOf(',');
+
+  if (start <= commaIndex) {
+    const digitIndex = countDigits(previousText.slice(0, start));
+    // Digitar sobre o zero inicial substitui, em vez de virar "09".
+    const base = buffer.intDigits === '0' ? '' : buffer.intDigits;
+    return withIntDigits(buffer, base.slice(0, digitIndex) + inserted + base.slice(digitIndex));
+  }
+
+  // Nos centavos as duas casas ja existem, entao o digito SOBRESCREVE em vez de inserir.
+  const position = clampDecimalPosition(start - commaIndex - 1);
+  const digits = buffer.decDigits.split('');
+  digits[position] = inserted;
+
+  return {
+    ...buffer,
+    decDigits: digits.join(''),
+    mode: 'decimal',
+    decCaret: position + 1,
+  };
+};
+
+const applyRemoval = (buffer, previousText, start, removed) => {
+  const commaIndex = previousText.indexOf(',');
+
+  if (removed === ',') {
+    return { ...buffer, decDigits: '00', mode: 'integer', decCaret: 2 };
+  }
+
+  if (removed === '.') {
+    // Apagar um separador de milhar apaga o digito imediatamente anterior a ele.
+    const digitIndex = countDigits(previousText.slice(0, start));
+    return withIntDigits(
+      buffer,
+      buffer.intDigits.slice(0, Math.max(digitIndex - 1, 0)) + buffer.intDigits.slice(digitIndex),
+    );
+  }
+
+  if (!/\d/.test(removed)) {
+    return buffer;
+  }
+
+  if (start < commaIndex) {
+    const digitIndex = countDigits(previousText.slice(0, start));
+    return withIntDigits(
+      buffer,
+      buffer.intDigits.slice(0, digitIndex) + buffer.intDigits.slice(digitIndex + 1),
+    );
+  }
+
+  const position = clampDecimalPosition(start - commaIndex - 1);
+  const digits = buffer.decDigits.split('');
+  digits[position] = '0';
+
+  return {
+    ...buffer,
+    decDigits: digits.join(''),
+    mode: 'decimal',
+    decCaret: position,
+  };
+};
+
+export const applyCurrencyInputChange = (buffer, nextText) => {
+  const previousText = formatCurrencyBuffer(buffer);
+
+  if (nextText === previousText) {
+    return buffer;
+  }
+
+  const { start, removed, inserted } = diffText(previousText, nextText);
+
+  // Colagem, ou selecao substituida: nao da para tratar como uma tecla, entao reparseia tudo.
+  if (inserted.length > 1 || (inserted && removed)) {
+    const amount = parseCurrencyInput(nextText);
+    return amount === null ? buffer : createCurrencyBufferFromAmount(amount);
+  }
+
+  if (inserted) {
+    return applyInsertion(buffer, previousText, start, inserted);
+  }
+
+  if (removed) {
+    return applyRemoval(buffer, previousText, start, removed);
+  }
+
+  return buffer;
+};


### PR DESCRIPTION
Fecha parcialmente #65 e entrega #106.

> **Status: em review, aguardando validação manual.** Este PR já está publicado por OTA e rodando no aparelho da usuária zero. Não mergear antes do teste manual em iOS e Android.

## Dois commits, dois problemas

### `80318b0` — sinal em tempo real (#65)

O campo abria pré-preenchido com `0,00` e não limpava ao focar, então digitar `9` produzia o texto `0,009` e o agendamento era **salvo com R$ 0,01**. `handleSaveAppointment` reparseava a string do campo; agora usa o valor numérico do form.

A formatação saiu do `onBlur` para cada tecla. `9` → `9,00`, `0` → `90,00`, centavos pela vírgula. A regra de que `90` vale R$ 90,00 (e não R$ 0,90) continua valendo — mudou só o momento da formatação, o que revoga a decisão de 2026-07-22 registrada na #65.

Com `,00` sempre visível e o cursor no fim, todo dígito novo cairia nos centavos. Por isso a fonte de verdade virou um buffer de dígitos, não a string exibida, e o cursor é controlado (`selection`) para ficar ancorado antes da vírgula.

### `8a047ca` — agenda por dia a partir de hoje (#106)

`buildInitialAgendaUtcRange` montava a janela inicial começando em **amanhã**, então a Agenda abria no próximo dia com atendimento e **escondia o de hoje**. A função foi removida.

Agora: janela de hoje até hoje+30 dias, `SectionList` com uma seção por dia, `HOJE`/`AMANHÃ` destacados, hoje sempre presente mesmo vazio. Rolar até o fim anexa mais 30 dias (teto de 12 meses). O botão de calendário rola até a seção em vez de trocar o dia. O resumo do topo virou do período; `Livres` saiu e entrou `Dias ocupados`.

## Arquivos novos

| Arquivo | Papel |
|---|---|
| `src/utils/currency.js` | helpers de moeda + máquina da máscara, lógica pura |
| `src/hooks/useCurrencyInput.js` | liga o buffer ao `TextInput`, controla o cursor |
| `src/screens/calendar/agendaWindow.js` | janela deslizante e agrupamento por dia, lógica pura |
| `src/utils/__tests__/currency.test.js` | 18 testes |
| `src/screens/calendar/__tests__/agendaWindow.test.js` | 18 testes |

## Validação feita

- **36 testes passando.** Cobrem a escada de digitação inteira (texto e posição do cursor em cada passo), a regressão do `0,009`, e a regressão do bootstrap ("hoje nunca é pulado").
- Parse/transpilação Babel dos 5 arquivos; `git diff --check` limpo; JSONs válidos.

> ⚠️ **`develop` não tem jest configurado.** As dependências (`jest`, `jest-expo`, script `test`) vivem só na branch `feat/BEAUTY-104`. Os testes estão no formato jest e foram executados por um harness Babel temporário. Quando a #104 for integrada, `npm test` passa a pegar os dois arquivos sem nenhuma alteração neles.

## Validação pendente — bloqueia o merge

Itens que só aparecem no device:

- [ ] Abrir a Agenda com atendimento **hoje**: primeira seção é `HOJE` e o atendimento aparece
- [ ] Abrir sem nada hoje mas com algo em 3 dias: seção `HOJE` vazia, depois o dia com atendimento
- [ ] Rolar até o fim carrega +30 dias uma vez, sem loop de requisições
- [ ] Calendário: dia dentro da janela (rola), 60 dias à frente (estende), mês passado (reancora e mostra botão `Hoje`)
- [ ] Popover de ações acima do cabeçalho grudado, no Android
- [ ] **Cursor do sinal no Android** — `selection` controlado é propenso a jitter
- [ ] Teclado `decimal-pad` do Android expõe a vírgula? Sem ela não dá para digitar centavos
- [ ] Cancelar atendimento: some dos 3 indicadores e do contador da seção, mas continua restaurável
- [ ] Sinal em modo percentual recalcula ao trocar serviço; em modo manual não sobrescreve o digitado

## Mudança de comportamento

`selectedDate` passou de "dia exibido" para "dia focado": o botão `+` agora propõe **hoje 08:00** em vez do dia do próximo atendimento.

## Versão

`1.4.0` em `package.json`/`package-lock.json`. `app.json` preservado em `1.1.0` para não trocar o runtime OTA do binário instalado. API não foi alterada.
