### PR TITLE
feat: apaga atendimento cancelado da agenda

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beautyapp",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beautyapp",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "0BSD",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beautyapp",
   "license": "0BSD",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "index.js",
   "scripts": {
     "start": "npx expo start --clear --go",

--- a/src/screens/calendar/AgendaScreen.jsx
+++ b/src/screens/calendar/AgendaScreen.jsx
@@ -54,6 +54,7 @@ import {
 import api from '../../services/api';
 import { isSessionExpiredError } from '../../services/sessionManager';
 import {
+  archiveAppointment,
   createAppointment,
   listAppointments,
   updateAppointment,
@@ -67,7 +68,7 @@ const DEPOSIT_PERCENT_OPTIONS = [0, 15, 30];
 const AGENDA_END_REACHED_THRESHOLD = 0.4;
 const ACTION_ANIMATION_DURATION = 180;
 const ACTION_POPOVER_MAX_WIDTH = 268;
-const ACTION_POPOVER_ESTIMATED_HEIGHT = 210;
+const ACTION_POPOVER_ESTIMATED_HEIGHT = 250;
 const ACTION_POPOVER_SCREEN_MARGIN = 16;
 
 if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
@@ -230,6 +231,8 @@ const AgendaScreen = () => {
   const [actionPopoverPosition, setActionPopoverPosition] = useState(null);
   const [deleteConfirmationId, setDeleteConfirmationId] = useState(null);
   const [deletingAppointmentId, setDeletingAppointmentId] = useState(null);
+  const [archiveConfirmationId, setArchiveConfirmationId] = useState(null);
+  const [archivingAppointmentId, setArchivingAppointmentId] = useState(null);
   const [statusAnimationAppointmentId, setStatusAnimationAppointmentId] = useState(null);
   const [reduceMotionEnabled, setReduceMotionEnabled] = useState(false);
   const actionMenuAnimation = useRef(new Animated.Value(0)).current;
@@ -277,6 +280,7 @@ const AgendaScreen = () => {
     setExpandedAppointmentId(null);
     setActionPopoverPosition(null);
     setDeleteConfirmationId(null);
+    setArchiveConfirmationId(null);
   }, [actionMenuAnimation]);
 
   useEffect(() => {
@@ -1260,9 +1264,48 @@ const AgendaScreen = () => {
       closeAppointmentActions();
       refreshCalendarMarksForDates([appointment.startAt]);
     } catch (error) {
-      Alert.alert('Erro', error.response?.data?.error || 'Não foi possível excluir o atendimento.');
+      Alert.alert('Erro', error.response?.data?.error || 'Não foi possível cancelar o atendimento.');
     } finally {
       setDeletingAppointmentId(null);
+    }
+  };
+
+  const openArchiveConfirmation = (appointmentId) => {
+    animateNextLayout();
+    setDeleteConfirmationId(null);
+    setArchiveConfirmationId(appointmentId);
+  };
+
+  const closeArchiveConfirmation = () => {
+    animateNextLayout();
+    setArchiveConfirmationId(null);
+  };
+
+  // Some com o atendimento de vez. A API so aceita cancelados e passa a excluir
+  // arquivados das listagens, entao ele nao volta nem apos recarregar.
+  const handleArchiveAppointment = async (appointment) => {
+    if (archivingAppointmentId !== null) {
+      return;
+    }
+
+    setArchivingAppointmentId(appointment.id);
+    animateNextLayout();
+    setAppointments((prev) => prev.filter((item) => String(item.id) !== String(appointment.id)));
+    closeAppointmentActions();
+
+    try {
+      await archiveAppointment(appointment.id);
+      // Sem refreshCalendarMarksForDates: cancelado nunca entrou nos marcadores.
+    } catch (error) {
+      animateNextLayout();
+      setAppointments((prev) => (
+        prev.some((item) => String(item.id) === String(appointment.id))
+          ? prev
+          : sortAppointments([...prev, appointment])
+      ));
+      Alert.alert('Erro', getAppointmentErrorMessage(error, 'Não foi possível apagar o atendimento.'));
+    } finally {
+      setArchivingAppointmentId(null);
     }
   };
 
@@ -1277,6 +1320,8 @@ const AgendaScreen = () => {
 
     const isConfirmingDelete = String(deleteConfirmationId) === String(appointment.id);
     const isDeleting = String(deletingAppointmentId) === String(appointment.id);
+    const isConfirmingArchive = String(archiveConfirmationId) === String(appointment.id);
+    const isArchiving = String(archivingAppointmentId) === String(appointment.id);
     const opensBelow = actionPopoverPosition.placement === 'below';
     const animatedPopoverStyle = {
       opacity: actionMenuAnimation,
@@ -1325,13 +1370,51 @@ const AgendaScreen = () => {
           ]}
         >
           {appointment.status === 'canceled' ? (
-            <TouchableOpacity
-              style={styles.actionMenuItem}
-              onPress={() => handleStatusChange(appointment.id, 'scheduled')}
-            >
-              <Ionicons name="arrow-undo-outline" size={18} color={colors.primary} />
-              <Text style={styles.actionMenuText}>Restaurar atendimento</Text>
-            </TouchableOpacity>
+            !isConfirmingArchive ? (
+              <>
+                <TouchableOpacity
+                  style={styles.actionMenuItem}
+                  onPress={() => handleStatusChange(appointment.id, 'scheduled')}
+                >
+                  <Ionicons name="arrow-undo-outline" size={18} color={colors.primary} />
+                  <Text style={styles.actionMenuText}>Restaurar atendimento</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={styles.actionMenuItem}
+                  onPress={() => openArchiveConfirmation(appointment.id)}
+                >
+                  <Ionicons name="trash-outline" size={18} color={colors.error} />
+                  <Text style={[styles.actionMenuText, styles.destructiveActionText]}>
+                    Apagar da agenda
+                  </Text>
+                </TouchableOpacity>
+              </>
+            ) : (
+              <View style={styles.deleteConfirmation}>
+                <Text style={styles.deleteConfirmationTitle}>Apagar da agenda?</Text>
+                <Text style={styles.deleteConfirmationText}>
+                  Ele some da agenda para sempre e não poderá ser restaurado pelo app.
+                </Text>
+                <View style={styles.deleteConfirmationActions}>
+                  <TouchableOpacity
+                    style={styles.deleteConfirmationSecondaryButton}
+                    onPress={closeArchiveConfirmation}
+                    disabled={isArchiving}
+                  >
+                    <Text style={styles.deleteConfirmationSecondaryText}>Manter</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    style={[styles.deleteConfirmationButton, isArchiving && styles.disabledButton]}
+                    onPress={() => handleArchiveAppointment(appointment)}
+                    disabled={isArchiving}
+                  >
+                    <Text style={styles.deleteConfirmationButtonText}>
+                      {isArchiving ? 'Apagando...' : 'Apagar da agenda'}
+                    </Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
+            )
           ) : !isConfirmingDelete ? (
             <>
               <TouchableOpacity style={styles.actionMenuItem} onPress={() => openEditModal(appointment)}>
@@ -1351,17 +1434,17 @@ const AgendaScreen = () => {
                 style={styles.actionMenuItem}
                 onPress={() => openDeleteConfirmation(appointment.id)}
               >
-                <Ionicons name="trash-outline" size={18} color={colors.error} />
+                <Ionicons name="close-circle-outline" size={18} color={colors.error} />
                 <Text style={[styles.actionMenuText, styles.destructiveActionText]}>
-                  Excluir atendimento
+                  Cancelar atendimento
                 </Text>
               </TouchableOpacity>
             </>
           ) : (
             <View style={styles.deleteConfirmation}>
-              <Text style={styles.deleteConfirmationTitle}>Excluir atendimento?</Text>
+              <Text style={styles.deleteConfirmationTitle}>Cancelar atendimento?</Text>
               <Text style={styles.deleteConfirmationText}>
-                Ele ficará cancelado, sem ocupar o horário, e poderá ser restaurado depois.
+                Ele fica cancelado, sem ocupar o horário, e pode ser restaurado ou apagado depois.
               </Text>
               <View style={styles.deleteConfirmationActions}>
                 <TouchableOpacity
@@ -1377,7 +1460,7 @@ const AgendaScreen = () => {
                   disabled={isDeleting}
                 >
                   <Text style={styles.deleteConfirmationButtonText}>
-                    {isDeleting ? 'Excluindo...' : 'Excluir atendimento'}
+                    {isDeleting ? 'Cancelando...' : 'Cancelar atendimento'}
                   </Text>
                 </TouchableOpacity>
               </View>

--- a/src/services/private/appointmentAPI.js
+++ b/src/services/private/appointmentAPI.js
@@ -22,3 +22,10 @@ export const updateAppointmentStatus = async (id, status) => {
   const response = await api.patch(`/appointments/${id}/status`, { status });
   return response.data;
 };
+
+// Marca `archivedAt` no atendimento. A API so aceita registros ja cancelados e
+// passa a excluir arquivados das listagens, entao ele nao volta a aparecer.
+export const archiveAppointment = async (id) => {
+  const response = await api.patch(`/appointments/${id}/archive`);
+  return response.data;
+};


### PR DESCRIPTION
Fecha #101. Consolida também `lBorD/api#37`, cuja parte de backend já estava entregue.

## Origem

Feedback da usuária zero em 2026-08-11: o cancelamento com card apagado foi **aprovado, fica como está**. O pedido novo é sumir com o atendimento de vez, e o fluxo em dois passos (cancelar → voltar depois e apagar) foi explicitamente aceito por ela.

## Zero trabalho de API

O backend já estava em produção desde a api **v1.2.0**, entregue em 22/07:

- `PATCH /appointments/:id/archive` — só aceita `canceled` (409 caso contrário), valida dono, idempotente
- `GET /appointments` já exclui arquivados por padrão (`where.archivedAt = null`)
- Arquivados não podem ser editados nem ter status alterado
- Migration `20260722000100-add-archived-at-to-appointments.cjs`

Este PR só liga o app ao que já existe. **Nenhum endpoint novo, migration ou mudança de contrato.**

## O que muda

**`src/services/private/appointmentAPI.js`** — wrapper `archiveAppointment(id)`.

**`src/screens/calendar/AgendaScreen.jsx`** — o popover do ramo `canceled` tinha só `Restaurar atendimento`; agora tem também `Apagar da agenda`, com confirmação inline no mesmo padrão já usado (sem `Modal` nativo). Remoção otimista da lista, com o card voltando ao lugar ordenado se a chamada falhar.

## Correção de copy

`Excluir atendimento` **nunca excluiu** — faz cancelamento lógico. Com um `Apagar` ao lado, ficariam duas palavras destrutivas com efeitos muito diferentes na mesma tela. Então:

| Antes | Depois |
|---|---|
| `Excluir atendimento` (ícone lixeira) | `Cancelar atendimento` (ícone X) |
| "Ele ficará cancelado… e poderá ser restaurado depois." | "Ele fica cancelado… e pode ser restaurado ou apagado depois." |
| — | `Apagar da agenda` (ícone lixeira, só em cancelados) |

A lixeira agora pertence só à ação que realmente é definitiva.

## Detalhes de integração com a Agenda multi-dia (#106)

- `setAppointments(prev => prev.filter(...))` basta: `sections` deriva de `appointments`.
- Se era o único atendimento do dia, a seção some — correto. Hoje e o dia focado seguem com o placeholder.
- **Não** chama `refreshCalendarMarksForDates`: cancelados nunca entraram nos marcadores, então seria requisição desperdiçada.
- `ACTION_POPOVER_ESTIMATED_HEIGHT` de `210` → `250`: o ramo cancelado passou de 1 para 2 itens e ganhou bloco de confirmação. A constante decide se o popover abre acima ou abaixo.

## Validação feita

- 36 testes existentes seguem passando, sem regressão.
- Parse/transpilação Babel dos dois arquivos; `git diff --check` limpo.

## Validação pendente — iOS e Android

- [ ] Cancelar um atendimento e confirmar que o card fica apagado, como já era
- [ ] Nos três pontinhos do cancelado, ver `Restaurar atendimento` **e** `Apagar da agenda`
- [ ] Apagar: card some na hora; **pull-to-refresh e reabrir o app não o trazem de volta**
- [ ] Apagar o único atendimento do dia: a seção some (mas hoje continua com placeholder)
- [ ] Popover do cancelado em card no rodapé da lista — abre acima sem cortar a confirmação
- [ ] Tentar apagar sem rede: card volta ao lugar e aparece o alerta

## Ponto de atenção

**Não há como desfazer pelo app** — não existe endpoint de desarquivar; reversão só direto no banco. A confirmação diz isso ("some da agenda para sempre e não poderá ser restaurado pelo app"), mas vale conferir se o texto está claro o suficiente para ela.

## Versão

`1.4.1` em `package.json`/`package-lock.json`. `app.json` preservado em `1.1.0`.
