### PR TITLE
fix: filtra a agenda por dia e limita a lista a 2 dias

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beautyapp",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beautyapp",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "0BSD",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beautyapp",
   "license": "0BSD",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "main": "index.js",
   "scripts": {
     "start": "npx expo start --clear --go",

--- a/src/screens/calendar/AgendaScreen.jsx
+++ b/src/screens/calendar/AgendaScreen.jsx
@@ -39,7 +39,6 @@ import {
   buildAgendaWindow,
   buildCalendarGridUtcRange,
   endOfLocalDay,
-  findSectionIndexByKey,
   getLocalDateKey,
   getMonthKey,
   getNextAgendaWindowBlock,
@@ -47,6 +46,7 @@ import {
   isDayPlaceholder,
   isWithinWindow,
   mergeAppointmentsById,
+  selectAgendaSections,
   sortAppointments,
   startOfLocalDay,
   summarizeAgendaSections,
@@ -65,7 +65,10 @@ const DAY_START_HOUR = 8;
 const CLIENT_SEARCH_LIMIT = 30;
 const DEFAULT_DEPOSIT_PERCENT = 0;
 const DEPOSIT_PERCENT_OPTIONS = [0, 15, 30];
-const AGENDA_END_REACHED_THRESHOLD = 0.4;
+// A lista fica curta de proposito: hoje mais o proximo dia com atendimento.
+// A setinha do rodape revela os demais, de dois em dois.
+const AGENDA_VISIBLE_SECTIONS = 2;
+const AGENDA_SECTIONS_STEP = 2;
 const ACTION_ANIMATION_DURATION = 180;
 const ACTION_POPOVER_MAX_WIDTH = 268;
 const ACTION_POPOVER_ESTIMATED_HEIGHT = 250;
@@ -188,14 +191,14 @@ const AgendaScreen = () => {
   const bottomInset = Math.max(insets.bottom, 8);
   const screenRef = useRef(null);
   const actionButtonRefs = useRef({});
-  const sectionListRef = useRef(null);
-  const sectionsRef = useRef([]);
-  const scrollTargetRef = useRef(null);
-  const canLoadMoreRef = useRef(false);
   // "Hoje" fica congelado na montagem para os rotulos nao mudarem sozinhos
   // se o app ficar aberto durante a virada do dia.
   const todayRef = useRef(startOfLocalDay(new Date()));
   const [selectedDate, setSelectedDate] = useState(() => startOfLocalDay(new Date()));
+  // 'lista' = hoje + proximos, cortado em AGENDA_VISIBLE_SECTIONS.
+  // 'dia'   = so a data escolhida no calendario.
+  const [agendaViewMode, setAgendaViewMode] = useState('lista');
+  const [visibleSectionLimit, setVisibleSectionLimit] = useState(AGENDA_VISIBLE_SECTIONS);
   const [showDayPicker, setShowDayPicker] = useState(false);
   const [visibleCalendarMonth, setVisibleCalendarMonth] = useState(() => {
     const today = new Date();
@@ -213,7 +216,6 @@ const AgendaScreen = () => {
   // Espelha a janela para os handlers assincronos nao lerem closure velha.
   const windowRangeRef = useRef(agendaWindow);
   const [loadMoreState, setLoadMoreState] = useState('idle');
-  const [scrollRequestId, setScrollRequestId] = useState(0);
 
   const [appointments, setAppointments] = useState([]);
   const [clients, setClients] = useState([]);
@@ -369,26 +371,56 @@ const AgendaScreen = () => {
     [appointments],
   );
 
-  const sections = useMemo(() => buildAgendaSections({
+  const allSections = useMemo(() => buildAgendaSections({
     appointments,
     windowStart: agendaWindow.start,
     windowEnd: agendaWindow.end,
     referenceDate: todayRef.current,
-    focusedDate: selectedDate,
-  }), [appointments, agendaWindow, selectedDate]);
+    // So no modo dia: no modo lista, um dia escolhido antes nao pode injetar secao.
+    focusedDate: agendaViewMode === 'dia' ? selectedDate : null,
+  }), [appointments, agendaWindow, agendaViewMode, selectedDate]);
 
+  const sections = useMemo(() => selectAgendaSections(allSections, {
+    mode: agendaViewMode,
+    selectedDateKey: getLocalDateKey(selectedDate),
+    limit: visibleSectionLimit,
+  }), [allSections, agendaViewMode, selectedDate, visibleSectionLimit]);
+
+  // O resumo do topo acompanha o que esta na tela, nao a janela carregada.
   const windowSummary = useMemo(() => summarizeAgendaSections(sections), [sections]);
 
-  // O retry de scroll roda dentro de setTimeout, entao precisa das secoes por ref.
-  useEffect(() => {
-    sectionsRef.current = sections;
-  }, [sections]);
+  const hasAnyAppointmentInWindow = useMemo(
+    () => allSections.some((section) => section.data.some((item) => !isDayPlaceholder(item))),
+    [allSections],
+  );
+
+  // Sem nada na janela inteira, o estado vazio grande (com os atalhos de cadastro)
+  // substitui a lista. Senao apareceria junto do placeholder do dia, duplicado.
+  const isAgendaEmpty = agendaViewMode === 'lista' && !hasAnyAppointmentInWindow;
+  const listSections = isAgendaEmpty ? [] : sections;
 
   const isWindowShowingToday = isWithinWindow(
     todayRef.current,
     agendaWindow.start,
     agendaWindow.end,
   );
+
+  const showTodayButton = agendaViewMode === 'dia' || !isWindowShowingToday;
+
+  // A setinha some so quando nao ha mais nada: nem secao carregada, nem dia adiante.
+  const canShowMoreSections = agendaViewMode === 'lista'
+    && (allSections.length > sections.length || loadMoreState !== 'exhausted');
+
+  // A legenda tem que descrever o que esta na tela, nao a janela carregada.
+  const visibleRangeLabel = useMemo(() => {
+    if (sections.length === 0) {
+      return formatShortDate(selectedDate);
+    }
+
+    const first = formatShortDate(sections[0].date);
+    const last = formatShortDate(sections[sections.length - 1].date);
+    return first === last ? first : `${first} a ${last}`;
+  }, [sections, selectedDate]);
 
   const loadClientAvailability = async () => {
     try {
@@ -635,64 +667,57 @@ const AgendaScreen = () => {
     loadCalendarMarks(nextMonth);
   };
 
-  const requestScrollToDate = (date) => {
-    scrollTargetRef.current = { key: getLocalDateKey(date), attempts: 0 };
-    setScrollRequestId((id) => id + 1);
-  };
-
-  const focusDate = async (date) => {
-    const target = startOfLocalDay(date);
+  // Escolher uma data no calendario filtra a agenda naquele dia, e so nele.
+  const handlePickDate = async (pickedDate) => {
+    setShowDayPicker(false);
+    const target = startOfLocalDay(pickedDate);
     closeAppointmentActions();
+    animateNextLayout();
     setSelectedDate(target);
     setVisibleCalendarMonth(new Date(target.getFullYear(), target.getMonth(), 1));
+    setAgendaViewMode('dia');
     await ensureDateVisible(target);
-    requestScrollToDate(target);
   };
 
-  const handlePickDate = (pickedDate) => {
-    setShowDayPicker(false);
-    focusDate(pickedDate);
+  const handleBackToToday = async () => {
+    const today = todayRef.current;
+    closeAppointmentActions();
+    animateNextLayout();
+    setSelectedDate(today);
+    setVisibleCalendarMonth(new Date(today.getFullYear(), today.getMonth(), 1));
+    setAgendaViewMode('lista');
+    setVisibleSectionLimit(AGENDA_VISIBLE_SECTIONS);
+
+    if (!isWithinLoadedWindow(today)) {
+      await loadAgendaWindow(today);
+    }
   };
 
-  const handleBackToToday = () => focusDate(todayRef.current);
+  const handleShowMoreSections = () => {
+    animateNextLayout();
+    const nextLimit = visibleSectionLimit + AGENDA_SECTIONS_STEP;
+    setVisibleSectionLimit(nextLimit);
 
-  const handleEndReached = () => {
-    if (!canLoadMoreRef.current || loadMoreState !== 'idle') {
+    // Acabaram os dias ja carregados: busca o proximo bloco antes que ela chegue nele.
+    if (nextLimit >= allSections.length && loadMoreState === 'idle') {
+      extendAgendaWindow();
+    }
+  };
+
+  // Depois de salvar, so mexe na view se o dia salvo nao estiver a vista.
+  // Assim criar para hoje nao tira amanha da tela, e criar para daqui a 20 dias
+  // ainda mostra o que acabou de ser criado.
+  const revealSavedAppointment = async (startAt) => {
+    if (sections.some((section) => section.key === getLocalDateKey(startAt))) {
       return;
     }
-    // Sem essa guarda, uma agenda curta dispara onEndReached ja na montagem e
-    // encadeia requisicoes ate o teto de lookahead.
-    canLoadMoreRef.current = false;
-    extendAgendaWindow();
-  };
 
-  // Sem getItemLayout (os cards tem altura variavel) o scroll para um indice ainda
-  // nao renderizado falha; aqui aproximamos e tentamos de novo, no maximo 3 vezes.
-  const handleScrollToIndexFailed = (info) => {
-    const target = scrollTargetRef.current;
-
-    if (!target || target.attempts >= 3) {
-      scrollTargetRef.current = null;
-      return;
-    }
-
-    target.attempts += 1;
-    sectionListRef.current?.getScrollResponder()?.scrollTo({
-      y: Math.max(0, (info.averageItemLength || 96) * info.index),
-      animated: false,
-    });
-
-    setTimeout(() => {
-      const sectionIndex = findSectionIndexByKey(sectionsRef.current, target.key);
-      if (sectionIndex >= 0) {
-        sectionListRef.current?.scrollToLocation({
-          sectionIndex,
-          itemIndex: 0,
-          viewPosition: 0,
-          animated: false,
-        });
-      }
-    }, 120);
+    const target = startOfLocalDay(startAt);
+    animateNextLayout();
+    setSelectedDate(target);
+    setVisibleCalendarMonth(new Date(target.getFullYear(), target.getMonth(), 1));
+    setAgendaViewMode('dia');
+    await ensureDateVisible(target);
   };
 
   useEffect(() => {
@@ -721,34 +746,6 @@ const AgendaScreen = () => {
     bootstrap();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  // Rola ate a secao pedida. Depende de `sections` porque a secao pode so
-  // existir depois que a janela terminar de carregar.
-  useEffect(() => {
-    const target = scrollTargetRef.current;
-
-    // `consumed` evita que qualquer mudanca posterior em `sections` (troca de
-    // status, carregar mais dias) role a lista de volta para o alvo antigo.
-    if (!target || target.consumed || sections.length === 0) {
-      return;
-    }
-
-    const sectionIndex = findSectionIndexByKey(sections, target.key);
-
-    if (sectionIndex < 0) {
-      return;
-    }
-
-    target.consumed = true;
-    sectionListRef.current?.scrollToLocation({
-      sectionIndex,
-      itemIndex: 0,
-      viewPosition: 0,
-      viewOffset: 0,
-      animated: !reduceMotionEnabled,
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [scrollRequestId, sections]);
 
   useEffect(() => {
     if (!modalVisible) {
@@ -1062,7 +1059,7 @@ const AgendaScreen = () => {
         });
         closeModal();
         refreshCalendarMarksForDates([previousAppointment?.startAt, updated.startAt]);
-        focusDate(new Date(updated.startAt));
+        revealSavedAppointment(updated.startAt);
       } catch (error) {
         if (!allowConflict && isAppointmentConflictError(error)) {
           showAppointmentConflictFeedback();
@@ -1084,8 +1081,7 @@ const AgendaScreen = () => {
       }
       closeModal();
       refreshCalendarMarksForDates([created.startAt]);
-      // Leva a usuaria ate o dia salvo, mesmo que ele esteja fora da janela atual.
-      focusDate(new Date(created.startAt));
+      revealSavedAppointment(created.startAt);
     } catch (error) {
       if (!allowConflict && isAppointmentConflictError(error)) {
         showAppointmentConflictFeedback();
@@ -1629,7 +1625,20 @@ const AgendaScreen = () => {
 
   const renderAgendaFooter = () => (
     <View>
-      {windowSummary.appointments === 0 && renderEmptyAgenda()}
+      {isAgendaEmpty && renderEmptyAgenda()}
+
+      {canShowMoreSections && loadMoreState !== 'loading' && (
+        <TouchableOpacity
+          style={styles.showMoreButton}
+          hitSlop={{ top: 10, right: 24, bottom: 10, left: 24 }}
+          onPress={handleShowMoreSections}
+          accessibilityRole="button"
+          accessibilityLabel="Exibir mais agendamentos"
+        >
+          <Ionicons name="chevron-down" size={18} color={colors.darkGray} />
+        </TouchableOpacity>
+      )}
+
       {loadMoreState === 'loading' && (
         <Text style={styles.footerText}>Carregando mais dias...</Text>
       )}
@@ -1637,9 +1646,6 @@ const AgendaScreen = () => {
         <TouchableOpacity style={styles.footerButton} onPress={extendAgendaWindow}>
           <Text style={styles.footerButtonText}>Não deu para carregar. Tentar novamente</Text>
         </TouchableOpacity>
-      )}
-      {loadMoreState === 'exhausted' && (
-        <Text style={styles.footerText}>Você chegou ao fim dos próximos 12 meses.</Text>
       )}
     </View>
   );
@@ -1714,7 +1720,7 @@ const AgendaScreen = () => {
       <View style={styles.headerRow}>
         <Text style={styles.title}>Agenda</Text>
         <View style={styles.headerActions}>
-          {!isWindowShowingToday && (
+          {showTodayButton && (
             <TouchableOpacity style={styles.todayButton} onPress={handleBackToToday}>
               <Text style={styles.todayButtonText}>Hoje</Text>
             </TouchableOpacity>
@@ -1749,20 +1755,19 @@ const AgendaScreen = () => {
             <Text style={styles.summaryLabel}>Previsto</Text>
             <Text style={styles.summaryValue}>{formatCurrency(windowSummary.forecast)}</Text>
           </View>
-          <View>
-            <Text style={styles.summaryLabel}>Dias ocupados</Text>
-            <Text style={styles.summaryValue}>{windowSummary.busyDays}</Text>
-          </View>
+          {agendaViewMode === 'lista' && (
+            <View>
+              <Text style={styles.summaryLabel}>Dias ocupados</Text>
+              <Text style={styles.summaryValue}>{windowSummary.busyDays}</Text>
+            </View>
+          )}
         </View>
-        <Text style={styles.summaryPeriod}>
-          {formatShortDate(agendaWindow.start)} a {formatShortDate(agendaWindow.end)}
-        </Text>
+        <Text style={styles.summaryPeriod}>{visibleRangeLabel}</Text>
       </View>
 
       <SectionList
-        ref={sectionListRef}
         style={styles.list}
-        sections={sections}
+        sections={listSections}
         keyExtractor={(item) => (
           isDayPlaceholder(item) ? `empty-${item.dateKey}` : String(item.id)
         )}
@@ -1775,10 +1780,6 @@ const AgendaScreen = () => {
           { paddingBottom: 96 + bottomInset },
         ]}
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
-        onEndReachedThreshold={AGENDA_END_REACHED_THRESHOLD}
-        onMomentumScrollBegin={() => { canLoadMoreRef.current = true; }}
-        onEndReached={handleEndReached}
-        onScrollToIndexFailed={handleScrollToIndexFailed}
         onScrollBeginDrag={closeAppointmentActions}
         ListFooterComponent={renderAgendaFooter}
         initialNumToRender={12}
@@ -2163,6 +2164,13 @@ const styles = StyleSheet.create({
   emptyDayText: {
     color: colors.darkGray,
     fontSize: 13,
+  },
+  // Deliberadamente discreta: so a setinha, sem borda, fundo ou texto.
+  showMoreButton: {
+    alignSelf: 'center',
+    paddingVertical: 6,
+    paddingHorizontal: 16,
+    opacity: 0.65,
   },
   footerText: {
     marginTop: 8,

--- a/src/screens/calendar/__tests__/agendaWindow.test.js
+++ b/src/screens/calendar/__tests__/agendaWindow.test.js
@@ -4,13 +4,13 @@ import {
   buildAgendaSections,
   buildAgendaWindow,
   endOfLocalDay,
-  findSectionIndexByKey,
   getLocalDateKey,
   getNextAgendaWindowBlock,
   getRelativeDayLabel,
   isDayPlaceholder,
   isWithinWindow,
   mergeAppointmentsById,
+  selectAgendaSections,
   startOfLocalDay,
   summarizeAgendaSections,
 } from '../agendaWindow';
@@ -202,17 +202,97 @@ describe('resumo do periodo', () => {
 });
 
 describe('navegacao entre secoes', () => {
-  it('acha o indice da secao pelo dia', () => {
-    const sections = sectionsFor([
-      buildAppointment({ id: 1, dayOffset: 2 }),
-      buildAppointment({ id: 2, dayOffset: 5 }),
-    ]);
-
-    expect(findSectionIndexByKey(sections, '2026-08-16')).toBe(2);
-    expect(findSectionIndexByKey(sections, '2026-08-20')).toBe(-1);
-  });
-
   it('nao rotula dias distantes como hoje ou amanha', () => {
     expect(getRelativeDayLabel(atLocalTime(2, 9), TODAY)).toBeNull();
+  });
+});
+
+describe('recorte do que fica visivel', () => {
+  const manyDays = [
+    buildAppointment({ id: 1, dayOffset: 0 }),
+    buildAppointment({ id: 2, dayOffset: 1 }),
+    buildAppointment({ id: 3, dayOffset: 4 }),
+    buildAppointment({ id: 4, dayOffset: 7 }),
+  ];
+
+  const asList = (sections, limit) => selectAgendaSections(sections, {
+    mode: 'lista',
+    selectedDateKey: null,
+    limit,
+  });
+
+  it('corta em 2 secoes no modo lista', () => {
+    const visible = asList(sectionsFor(manyDays), 2);
+
+    expect(visible.map((section) => section.key)).toEqual(['2026-08-11', '2026-08-12']);
+  });
+
+  it('hoje e sempre a primeira secao, mesmo vazio', () => {
+    // Cenario do bug: hoje sem atendimento, proximo em 3 dias.
+    const visible = asList(sectionsFor([buildAppointment({ id: 1, dayOffset: 3 })]), 2);
+
+    expect(visible.map((section) => section.key)).toEqual(['2026-08-11', '2026-08-14']);
+    expect(isDayPlaceholder(visible[0].data[0])).toBe(true);
+  });
+
+  it('pula dias vazios porque eles nao viram secao', () => {
+    // Amanha vazio: a segunda vaga vai para o proximo dia COM atendimento.
+    const visible = asList(sectionsFor([
+      buildAppointment({ id: 1, dayOffset: 0 }),
+      buildAppointment({ id: 2, dayOffset: 4 }),
+    ]), 2);
+
+    expect(visible.map((section) => section.key)).toEqual(['2026-08-11', '2026-08-15']);
+  });
+
+  it('revela mais dias quando o limite cresce', () => {
+    const sections = sectionsFor(manyDays);
+
+    expect(asList(sections, 4)).toHaveLength(4);
+    expect(asList(sections, 99)).toHaveLength(sections.length);
+  });
+
+  it('nunca devolve lista vazia no modo lista', () => {
+    expect(asList(sectionsFor(manyDays), 0)).toHaveLength(1);
+  });
+
+  it('devolve so a data escolhida no modo dia', () => {
+    const visible = selectAgendaSections(sectionsFor(manyDays, atLocalTime(4, 9)), {
+      mode: 'dia',
+      selectedDateKey: '2026-08-15',
+      limit: 2,
+    });
+
+    expect(visible).toHaveLength(1);
+    expect(visible[0].key).toBe('2026-08-15');
+    expect(visible[0].data.map((item) => item.id)).toEqual([3]);
+  });
+
+  it('no modo dia, dia sem atendimento vem com placeholder', () => {
+    const chosen = atLocalTime(6, 9);
+    const visible = selectAgendaSections(sectionsFor(manyDays, chosen), {
+      mode: 'dia',
+      selectedDateKey: getLocalDateKey(chosen),
+      limit: 2,
+    });
+
+    expect(visible).toHaveLength(1);
+    expect(visible[0].key).toBe('2026-08-17');
+    expect(isDayPlaceholder(visible[0].data[0])).toBe(true);
+  });
+
+  it('resumo do topo acompanha so o que esta visivel', () => {
+    const sections = sectionsFor([
+      buildAppointment({ id: 1, dayOffset: 0, price: 100 }),
+      buildAppointment({ id: 2, dayOffset: 1, price: 200 }),
+      buildAppointment({ id: 3, dayOffset: 5, price: 900 }),
+    ]);
+
+    expect(summarizeAgendaSections(asList(sections, 2))).toEqual({
+      appointments: 2,
+      forecast: 300,
+      busyDays: 2,
+    });
+    expect(summarizeAgendaSections(asList(sections, 99)).forecast).toBe(1200);
   });
 });

--- a/src/screens/calendar/agendaWindow.js
+++ b/src/screens/calendar/agendaWindow.js
@@ -197,6 +197,13 @@ export const summarizeAgendaSections = (sections) => sections.reduce((totals, se
   busyDays: totals.busyDays + (section.activeCount > 0 ? 1 : 0),
 }), { appointments: 0, forecast: 0, busyDays: 0 });
 
-export const findSectionIndexByKey = (sections, dateKey) => (
-  sections.findIndex((section) => section.key === dateKey)
+// Recorta o que fica visivel na tela.
+//
+// No modo 'dia' mostra so a data escolhida no calendario. No modo 'lista' corta
+// nas primeiras `limit` secoes: como dia vazio nao gera secao, isso e o mesmo
+// que "hoje mais o proximo dia com atendimento".
+export const selectAgendaSections = (sections, { mode, selectedDateKey, limit }) => (
+  mode === 'dia'
+    ? sections.filter((section) => section.key === selectedDateKey)
+    : sections.slice(0, Math.max(limit, 1))
 );


### PR DESCRIPTION
Fecha #109. Hotfix sobre o comportamento entregue em #106, que já está no aparelho da usuária zero.

## 1. Bug — o seletor de data não filtrava

Ao aprovar o design multi-dia, a opção escolhida foi "o botão de calendário rola até a seção do dia". Na prática não era isso: escolher uma data deve exibir **somente aquela data**.

Agora `handlePickDate` entra no modo `dia` e a lista mostra só o dia escolhido. O botão `Hoje` no header — que antes só aparecia quando a janela não continha hoje — passa a aparecer sempre que estiver filtrado, e volta para a visão normal já recolhida em 2 dias.

## 2. Limite de 2 dias com setinha

A lista mostra no máximo **2 blocos de dia**. Abaixo do último, um `chevron-down` discreto (sem borda, sem fundo, sem texto, `opacity: 0.65`, área de toque de 44 px) revela **+2 dias por toque**.

**Nota que simplificou tudo:** dia vazio já não gera seção — `buildAgendaSections` só cria bucket para dias com agendamento, mais hoje, mais o `focusedDate`. Então "hoje + próximo dia com atendimento" é literalmente "as 2 primeiras seções", sem lógica de pular vazios.

## Efeito colateral: remoção de código frágil

Com a lista curta, `onEndReached` dispararia já na montagem e encadearia requisições até o teto de 12 meses. A setinha vira o **único** gatilho de carregamento, e isso tornou morta toda a maquinaria de scroll programático:

- `scrollTargetRef`, `sectionsRef`, `scrollRequestId`, `requestScrollToDate`, `sectionListRef`
- o `useEffect` de scroll e o que espelhava `sectionsRef`
- `handleScrollToIndexFailed` com o retry de 3 tentativas
- `findSectionIndexByKey` em `agendaWindow.js`
- `canLoadMoreRef`, `AGENDA_END_REACHED_THRESHOLD`, `onMomentumScrollBegin`

Saldo: **−117 linhas** no `AgendaScreen`, incluindo o trecho mais frágil da entrega anterior.

## Outros ajustes

- **Resumo do topo** soma só os dias visíveis. A legenda passa a descrever o intervalo visível (ou a data, no modo `dia`), e o tile `Dias ocupados` some no modo `dia`, onde seria sempre 1.
- **Estado vazio**: quando não há nada na janela inteira, a lista dá lugar ao estado vazio grande com os atalhos de cadastro. Antes ele apareceria junto do placeholder "Nenhum atendimento" do dia, duplicado.
- **Após salvar**: em vez de sempre navegar, só entra no modo `dia` se o dia salvo não estiver visível. Criar para hoje não tira amanhã da tela; criar para daqui a 20 dias ainda mostra o resultado.

## Validação feita

- **43 testes passando** (eram 36). Sete novos cobrem o seletor: corte em 2, hoje sempre primeiro mesmo vazio, pular dias vazios, crescimento do limite, modo `dia` com e sem atendimento, e o resumo acompanhando o visível.
- Parse Babel dos arquivos; `git diff --check` limpo; nenhum símbolo morto restante.

## Validação pendente — iOS e Android

- [ ] Abrir a Agenda: no máximo 2 blocos
- [ ] Amanhã vazio e quinta com atendimento → blocos são `HOJE` e `quinta`
- [ ] Setinha revela 2 por vez e some só quando não há mais nada
- [ ] Escolher data → **somente aquele dia**; botão `Hoje` aparece
- [ ] Escolher dia sem atendimento → bloco com "Nenhum atendimento"
- [ ] `Hoje` volta recolhido em 2
- [ ] Data no mês passado → mostra só ela; `Hoje` traz de volta
- [ ] Resumo bate com a soma do que está na tela, nos dois modos
- [ ] Criar agendamento para 20 dias à frente → a tela mostra aquele dia

## Ponto de atenção

Um dia cujo único atendimento está **cancelado** ainda é seção (`activeCount: 0`, mas com card). Ele pode ocupar a 2ª vaga como "próximo". É consistente e mantém o card alcançável para restaurar ou apagar, mas é o ponto mais provável de estranhamento — vale observar no uso antes de complicar a regra.

## Versão

`1.4.2`. `app.json` preservado em `1.1.0`. Sem mudança de API.
