### PR TITLE
fix: compacta o indicador do Google e permite recolher a agenda

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beautyapp",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beautyapp",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "0BSD",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beautyapp",
   "license": "0BSD",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "main": "index.js",
   "scripts": {
     "start": "npx expo start --clear --go",

--- a/src/screens/calendar/AgendaScreen.jsx
+++ b/src/screens/calendar/AgendaScreen.jsx
@@ -21,6 +21,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import DateTimePickerModal from '../../components/DateTimePickerModal';
+import GoogleSyncBadge from './GoogleSyncBadge';
 import colors from '../../constants/colors';
 import useCurrencyInput from '../../hooks/useCurrencyInput';
 import {
@@ -88,18 +89,6 @@ const statusColors = {
   scheduled: '#1677ff',
   canceled: colors.error,
   completed: colors.success,
-};
-
-const googleSyncLabels = {
-  pending: 'Google pendente',
-  synced: 'Google sincronizado',
-  failed: 'Falha no Google',
-};
-
-const googleSyncColors = {
-  pending: colors.warning,
-  synced: colors.success,
-  failed: colors.error,
 };
 
 const getAppointmentServices = (appointment) => {
@@ -411,6 +400,9 @@ const AgendaScreen = () => {
   const canShowMoreSections = agendaViewMode === 'lista'
     && (allSections.length > sections.length || loadMoreState !== 'exhausted');
 
+  const canCollapseSections = agendaViewMode === 'lista'
+    && visibleSectionLimit > AGENDA_VISIBLE_SECTIONS;
+
   // A legenda tem que descrever o que esta na tela, nao a janela carregada.
   const visibleRangeLabel = useMemo(() => {
     if (sections.length === 0) {
@@ -702,6 +694,12 @@ const AgendaScreen = () => {
     if (nextLimit >= allSections.length && loadMoreState === 'idle') {
       extendAgendaWindow();
     }
+  };
+
+  const handleCollapseSections = () => {
+    animateNextLayout();
+    closeAppointmentActions();
+    setVisibleSectionLimit(AGENDA_VISIBLE_SECTIONS);
   };
 
   // Depois de salvar, so mexe na view se o dia salvo nao estiver a vista.
@@ -1571,27 +1569,10 @@ const AgendaScreen = () => {
               {getAppointmentServiceName(item) || 'Serviço'}
             </Text>
           </View>
-          {googleSyncLabels[item.googleSyncStatus] && (
-            <View style={[
-              styles.googleSyncBadge,
-              { borderColor: googleSyncColors[item.googleSyncStatus] || colors.border },
-            ]}>
-              <Ionicons
-                name={item.googleSyncStatus === 'failed' ? 'cloud-offline-outline' : 'cloud-done-outline'}
-                size={13}
-                color={googleSyncColors[item.googleSyncStatus] || colors.darkGray}
-              />
-              <Text
-                numberOfLines={2}
-                style={[
-                  styles.googleSyncBadgeText,
-                  { color: googleSyncColors[item.googleSyncStatus] || colors.darkGray },
-                ]}
-              >
-                {googleSyncLabels[item.googleSyncStatus]}
-              </Text>
-            </View>
-          )}
+          <GoogleSyncBadge
+            status={item.googleSyncStatus}
+            reduceMotion={reduceMotionEnabled}
+          />
         </View>
 
       </Animated.View>
@@ -1627,16 +1608,31 @@ const AgendaScreen = () => {
     <View>
       {isAgendaEmpty && renderEmptyAgenda()}
 
-      {canShowMoreSections && loadMoreState !== 'loading' && (
-        <TouchableOpacity
-          style={styles.showMoreButton}
-          hitSlop={{ top: 10, right: 24, bottom: 10, left: 24 }}
-          onPress={handleShowMoreSections}
-          accessibilityRole="button"
-          accessibilityLabel="Exibir mais agendamentos"
-        >
-          <Ionicons name="chevron-down" size={18} color={colors.darkGray} />
-        </TouchableOpacity>
+      {loadMoreState !== 'loading' && (canShowMoreSections || canCollapseSections) && (
+        <View style={styles.sectionToggleRow}>
+          {canCollapseSections && (
+            <TouchableOpacity
+              style={styles.sectionToggleButton}
+              hitSlop={{ top: 10, right: 16, bottom: 10, left: 16 }}
+              onPress={handleCollapseSections}
+              accessibilityRole="button"
+              accessibilityLabel="Recolher a lista de agendamentos"
+            >
+              <Ionicons name="chevron-up" size={18} color={colors.darkGray} />
+            </TouchableOpacity>
+          )}
+          {canShowMoreSections && (
+            <TouchableOpacity
+              style={styles.sectionToggleButton}
+              hitSlop={{ top: 10, right: 16, bottom: 10, left: 16 }}
+              onPress={handleShowMoreSections}
+              accessibilityRole="button"
+              accessibilityLabel="Exibir mais agendamentos"
+            >
+              <Ionicons name="chevron-down" size={18} color={colors.darkGray} />
+            </TouchableOpacity>
+          )}
+        </View>
       )}
 
       {loadMoreState === 'loading' && (
@@ -2165,11 +2161,16 @@ const styles = StyleSheet.create({
     color: colors.darkGray,
     fontSize: 13,
   },
-  // Deliberadamente discreta: so a setinha, sem borda, fundo ou texto.
-  showMoreButton: {
-    alignSelf: 'center',
+  // Deliberadamente discretas: so as setinhas, sem borda, fundo ou texto.
+  sectionToggleRow: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 20,
+  },
+  sectionToggleButton: {
     paddingVertical: 6,
-    paddingHorizontal: 16,
+    paddingHorizontal: 10,
     opacity: 0.65,
   },
   footerText: {
@@ -2282,22 +2283,6 @@ const styles = StyleSheet.create({
     marginTop: 1,
     fontSize: 13,
     lineHeight: 18,
-  },
-  googleSyncBadge: {
-    maxWidth: '44%',
-    flexShrink: 1,
-    borderWidth: 1,
-    borderRadius: 999,
-    paddingHorizontal: 7,
-    paddingVertical: 3,
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 4,
-  },
-  googleSyncBadgeText: {
-    flexShrink: 1,
-    fontSize: 11,
-    fontWeight: '700',
   },
   actionPopoverOverlay: {
     ...StyleSheet.absoluteFillObject,

--- a/src/screens/calendar/GoogleSyncBadge.jsx
+++ b/src/screens/calendar/GoogleSyncBadge.jsx
@@ -1,0 +1,133 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { LayoutAnimation, StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import colors from '../../constants/colors';
+
+export const googleSyncLabels = {
+  pending: 'Google pendente',
+  synced: 'Google sincronizado',
+  failed: 'Falha no Google',
+};
+
+const googleSyncColors = {
+  pending: colors.warning,
+  synced: colors.success,
+  failed: colors.error,
+};
+
+const EXPANDED_DURATION = 2600;
+const TRANSITION_DURATION = 200;
+
+// Em repouso mostra so a nuvem, na cor do status. O texto aparece apenas quando o
+// status muda de verdade, e some sozinho depois.
+//
+// Manter o texto sempre visivel era a causa do desalinhamento no iOS: com
+// `numberOfLines={2}` dentro de um pill estreito, o rotulo quebrava em duas linhas
+// e o `alignItems: 'center'` deixava a nuvem flutuando no meio do bloco. Agora o
+// texto nunca quebra (`numberOfLines={1}`) e no estado de repouso nem existe.
+const GoogleSyncBadge = ({ status, reduceMotion = false }) => {
+  const label = googleSyncLabels[status];
+  const previousStatusRef = useRef(status);
+  const collapseTimerRef = useRef(null);
+  const [expanded, setExpanded] = useState(false);
+
+  useEffect(() => {
+    // Na montagem nao expande: abrir a agenda nao pode animar todos os cards.
+    if (previousStatusRef.current === status) {
+      return undefined;
+    }
+
+    previousStatusRef.current = status;
+
+    if (!label) {
+      setExpanded(false);
+      return undefined;
+    }
+
+    if (!reduceMotion) {
+      LayoutAnimation.configureNext({
+        duration: TRANSITION_DURATION,
+        create: { type: LayoutAnimation.Types.easeInEaseOut, property: LayoutAnimation.Properties.opacity },
+        update: { type: LayoutAnimation.Types.easeInEaseOut },
+        delete: { type: LayoutAnimation.Types.easeInEaseOut, property: LayoutAnimation.Properties.opacity },
+      });
+    }
+
+    setExpanded(true);
+    clearTimeout(collapseTimerRef.current);
+    collapseTimerRef.current = setTimeout(() => {
+      if (!reduceMotion) {
+        LayoutAnimation.configureNext({
+          duration: TRANSITION_DURATION,
+          update: { type: LayoutAnimation.Types.easeInEaseOut },
+          delete: { type: LayoutAnimation.Types.easeInEaseOut, property: LayoutAnimation.Properties.opacity },
+        });
+      }
+      setExpanded(false);
+    }, EXPANDED_DURATION);
+
+    return undefined;
+  }, [label, reduceMotion, status]);
+
+  useEffect(() => () => clearTimeout(collapseTimerRef.current), []);
+
+  if (!label) {
+    return null;
+  }
+
+  const tone = googleSyncColors[status] || colors.darkGray;
+
+  return (
+    <View
+      style={[
+        styles.badge,
+        expanded ? styles.badgeExpanded : styles.badgeCompact,
+        { borderColor: tone },
+      ]}
+      accessibilityRole="image"
+      // O rotulo fica sempre disponivel para o leitor de tela, mesmo compacto.
+      accessibilityLabel={label}
+    >
+      <Ionicons
+        name={status === 'failed' ? 'cloud-offline-outline' : 'cloud-done-outline'}
+        size={13}
+        color={tone}
+      />
+      {expanded && (
+        <Text numberOfLines={1} style={[styles.badgeText, { color: tone }]}>
+          {label}
+        </Text>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  badge: {
+    flexShrink: 0,
+    borderWidth: 1,
+    borderRadius: 999,
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 3,
+  },
+  // Em repouso o pill vira um circulo com a nuvem dentro.
+  badgeCompact: {
+    paddingHorizontal: 4,
+  },
+  badgeExpanded: {
+    maxWidth: '60%',
+    flexShrink: 1,
+    paddingHorizontal: 7,
+    gap: 4,
+  },
+  badgeText: {
+    flexShrink: 1,
+    fontSize: 11,
+    fontWeight: '700',
+    // lineHeight explicito evita o desencontro vertical entre iOS e Android.
+    lineHeight: 14,
+  },
+});
+
+export default GoogleSyncBadge;


### PR DESCRIPTION
Fecha #65 — este era o último item em aberto da issue. Refs #109.

## 1. Indicador do Google

### A causa do desalinhamento no iOS

O badge renderizava ícone + texto **sempre expandidos**, dentro de um pill com `maxWidth: '44%'` e `numberOfLines={2}`. Com "Google sincronizado" nesse espaço, o rótulo quebrava em duas linhas; como o container usa `alignItems: 'center'`, a nuvem centralizava em relação ao bloco de duas linhas e ficava flutuando no meio. No iOS isso aparecia mais deslocado por causa da diferença de `lineHeight` padrão.

### O que passou a valer

Em repouso, **só a nuvem** na cor do status — o pill vira um círculo. O texto aparece **apenas quando o status muda de verdade** e some sozinho depois de 2,6s.

Isso resolve as duas metades do escopo de uma vez: sem texto em repouso, não há mais quebra de linha para desalinhar. Quando expande, `numberOfLines={1}` e um `lineHeight` explícito garantem que ícone e texto fiquem na mesma linha de base nas duas plataformas.

Detalhes:
- **Não expande na montagem.** Abrir a agenda não pode animar todos os cards de uma vez — a comparação é contra o status anterior, guardado em ref.
- **Respeita `Reduzir movimento`**: com a preferência ligada, a troca é instantânea, sem `LayoutAnimation`.
- **Acessibilidade preservada**: o rótulo continua sempre disponível para leitor de tela via `accessibilityLabel`, mesmo compacto.
- Timer limpo no unmount.

### Novo arquivo

`src/screens/calendar/GoogleSyncBadge.jsx`. A lógica saiu do `AgendaScreen` porque a detecção de mudança de status e a animação são **por card** — manter isso no pai exigiria um mapa de estado por id. Os `googleSyncLabels`/`googleSyncColors` foram junto, já que nada mais os usava.

## 2. Setinha para recolher

A lista ganhou um `^` ao lado do `⌄` que já existia, para voltar aos 2 dias. Aparece só quando a lista está expandida além do padrão. Mesmo tratamento discreto: sem borda, sem fundo, sem texto, `opacity: 0.65`, área de toque de 44 px.

Quando ambos cabem, ficam lado a lado com 20 px de respiro.

## Validação feita

- 43 testes seguem passando, sem regressão.
- Parse Babel dos dois arquivos; `git diff --check` limpo; nenhum símbolo morto restante.

## Validação pendente — iOS e Android

- [ ] **Alinhamento no iOS**: a nuvem compacta fica centrada no círculo
- [ ] Abrir a agenda **não** anima nenhum badge
- [ ] Criar um agendamento e observar o badge expandir ao sair de `pending` para `synced`, e recolher sozinho
- [ ] Com "Reduzir movimento" ligado: troca instantânea, sem animação
- [ ] VoiceOver/TalkBack lê o status mesmo com o badge compacto
- [ ] `^` recolhe para 2 dias; `^` e `⌄` juntos quando expandido e ainda há mais

## Ponto de atenção

Pelo escopo definido, **só mudança de status expande** — inclusive para `failed`. Uma falha persistente de sincronização fica apenas como uma nuvem vermelha, sem texto, até que o status mude de novo. Se na prática isso passar despercebido, vale abrir exceção para `failed` ficar sempre expandido.

## Versão

`1.4.3`. `app.json` preservado em `1.1.0`. Sem mudança de API.
