### PR TITLE
fix: calcula o topo das telas pela área segura

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beautyapp",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beautyapp",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "license": "0BSD",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beautyapp",
   "license": "0BSD",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "main": "index.js",
   "scripts": {
     "start": "npx expo start --clear --go",

--- a/src/hooks/useScreenTopPadding.js
+++ b/src/hooks/useScreenTopPadding.js
@@ -1,0 +1,29 @@
+import { Platform } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+// Respiro abaixo da status bar no Android.
+export const SCREEN_TOP_GAP_ANDROID = 16;
+// Espacamento ja validado no iOS, mantido como piso.
+export const SCREEN_TOP_BASE_IOS = 56;
+
+// Espacamento do topo das telas, que antes era um numero fixo (50 ou 56,
+// dependendo da tela) e ignorava o aparelho.
+//
+// As duas plataformas precisam de contas diferentes porque a origem do layout
+// nao e a mesma:
+//
+// - Android sem edge-to-edge: a status bar e opaca e fica FORA da viewport,
+//   entao `insets.top` e 0 e todo o espacamento vinha do numero fixo. Era dai
+//   que vinha a "testa" - 56px de vazio abaixo de uma barra que ja estava fora.
+// - iOS: o app desenha sob o notch, entao `insets.top` (20 a 59, conforme o
+//   modelo) ja reserva esse espaco. O piso preserva o visual atual e o
+//   `Math.max` cobre a Dynamic Island, onde 56 ficava 3px dentro da ilha.
+const useScreenTopPadding = () => {
+  const insets = useSafeAreaInsets();
+
+  return Platform.OS === 'android'
+    ? insets.top + SCREEN_TOP_GAP_ANDROID
+    : Math.max(insets.top, SCREEN_TOP_BASE_IOS);
+};
+
+export default useScreenTopPadding;

--- a/src/screens/calendar/AgendaScreen.jsx
+++ b/src/screens/calendar/AgendaScreen.jsx
@@ -24,6 +24,7 @@ import DateTimePickerModal from '../../components/DateTimePickerModal';
 import GoogleSyncBadge from './GoogleSyncBadge';
 import colors from '../../constants/colors';
 import useCurrencyInput from '../../hooks/useCurrencyInput';
+import useScreenTopPadding from '../../hooks/useScreenTopPadding';
 import {
   calculateDepositAmount,
   calculateRemainingAmount,
@@ -178,6 +179,7 @@ const AgendaScreen = () => {
   const insets = useSafeAreaInsets();
   const { width: windowWidth, height: windowHeight } = useWindowDimensions();
   const bottomInset = Math.max(insets.bottom, 8);
+  const topPadding = useScreenTopPadding();
   const screenRef = useRef(null);
   const actionButtonRefs = useRef({});
   // "Hoje" fica congelado na montagem para os rotulos nao mudarem sozinhos
@@ -1712,7 +1714,7 @@ const AgendaScreen = () => {
   }
 
   return (
-    <View ref={screenRef} style={styles.container}>
+    <View ref={screenRef} style={[styles.container, { paddingTop: topPadding }]}>
       <View style={styles.headerRow}>
         <Text style={styles.title}>Agenda</Text>
         <View style={styles.headerActions}>
@@ -2029,7 +2031,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: colors.background,
-    paddingTop: 56,
     paddingHorizontal: 16,
   },
   loadingContainer: {

--- a/src/screens/clients/cliente.jsx
+++ b/src/screens/clients/cliente.jsx
@@ -25,6 +25,7 @@ import formatPhoneNumber from '../../utils/formatNumber';
 import { validateFormData } from '../../utils/validations';
 import { formatBirthDay, formatDate, formatDateForInput } from '../../utils/formatBirthday';
 import useFeedbackModal from '../../hooks/useFeedbackModal';
+import useScreenTopPadding from '../../hooks/useScreenTopPadding';
 
 const getInitialEditedClient = () => ({
   name: '',
@@ -44,6 +45,7 @@ const hasOptionalClientInfo = (client) => Boolean(
 
 const ClientScreen = () => {
   const navigation = useNavigation();
+  const topPadding = useScreenTopPadding();
   const [clients, setClients] = useState([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -243,7 +245,7 @@ const ClientScreen = () => {
   }
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { paddingTop: topPadding }]}>
       <View style={styles.header}>
         <Text style={styles.screenTitle}>Clientes</Text>
         <HeaderAddButton
@@ -404,7 +406,6 @@ const ClientScreen = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    paddingTop: 50,
     backgroundColor: colors.background,
   },
   header: {

--- a/src/screens/clients/registerCustomer.jsx
+++ b/src/screens/clients/registerCustomer.jsx
@@ -10,9 +10,11 @@ import { validateFormData } from '../../utils/validations';
 import { formatBirthDay, formatDate } from '../../utils/formatBirthday';
 import colors from '../../constants/colors';
 import useFeedbackModal from '../../hooks/useFeedbackModal';
+import useScreenTopPadding from '../../hooks/useScreenTopPadding';
 
 export default function RegisterClientScreeen() {
   const navigation = useNavigation();
+  const topPadding = useScreenTopPadding();
   const { feedback, showFeedback, hideFeedback } = useFeedbackModal();
   const [showOptionalFields, setShowOptionalFields] = useState(false);
   const [formData, setFormData] = useState({
@@ -95,7 +97,7 @@ export default function RegisterClientScreeen() {
 
   return (
     <>
-      <ScrollView style={styles.container}>
+      <ScrollView style={[styles.container, { paddingTop: topPadding }]}>
         <View style={styles.formContainer}>
           <Text style={styles.title}>Cadastro de Cliente</Text>
 
@@ -199,7 +201,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: colors.background,
-    paddingTop: 50,
   },
   formContainer: {
     padding: 20,

--- a/src/screens/finance/FinancaScreen.jsx
+++ b/src/screens/finance/FinancaScreen.jsx
@@ -12,6 +12,7 @@ import {
 import { Ionicons } from '@expo/vector-icons';
 import { useFocusEffect } from '@react-navigation/native';
 import colors from '../../constants/colors';
+import useScreenTopPadding from '../../hooks/useScreenTopPadding';
 import { isSessionExpiredError } from '../../services/sessionManager';
 import { listAppointments } from '../../services/private/appointmentAPI';
 
@@ -322,6 +323,7 @@ const InsightModal = ({ insight, onClose }) => (
 );
 
 const FinancaScreen = () => {
+  const topPadding = useScreenTopPadding();
   const [appointments, setAppointments] = useState([]);
   const [referenceDate, setReferenceDate] = useState(new Date());
   const [loading, setLoading] = useState(true);
@@ -466,7 +468,7 @@ const FinancaScreen = () => {
   return (
     <ScrollView
       style={styles.container}
-      contentContainerStyle={styles.contentContainer}
+      contentContainerStyle={[styles.contentContainer, { paddingTop: topPadding }]}
       refreshControl={(
         <RefreshControl
           refreshing={refreshing}
@@ -579,7 +581,6 @@ const styles = StyleSheet.create({
     backgroundColor: colors.background,
   },
   contentContainer: {
-    paddingTop: 56,
     paddingHorizontal: 16,
     paddingBottom: 32,
   },

--- a/src/screens/services/EditServiceScreen.jsx
+++ b/src/screens/services/EditServiceScreen.jsx
@@ -6,9 +6,11 @@ import Button from '../../components/button';
 import FeedbackModal from '../../components/FeedbackModal';
 import { updateService } from '../../services/private/serviceAPI';
 import colors from '../../constants/colors';
+import useScreenTopPadding from '../../hooks/useScreenTopPadding';
 import useFeedbackModal from '../../hooks/useFeedbackModal';
 
 export default function EditServiceScreen() {
+  const topPadding = useScreenTopPadding();
   const navigation = useNavigation();
   const route = useRoute();
   const { service } = route.params;
@@ -160,7 +162,7 @@ export default function EditServiceScreen() {
 
   return (
     <>
-      <ScrollView style={styles.container}>
+      <ScrollView style={[styles.container, { paddingTop: topPadding }]}>
         <View style={styles.formContainer}>
           <Text style={styles.title}>Editar Serviço</Text>
 
@@ -239,7 +241,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#fff',
-    paddingTop: 50,
   },
   formContainer: {
     padding: 20,

--- a/src/screens/services/RegisterServiceScreen.jsx
+++ b/src/screens/services/RegisterServiceScreen.jsx
@@ -6,9 +6,11 @@ import Button from '../../components/button';
 import FeedbackModal from '../../components/FeedbackModal';
 import { registerService } from '../../services/private/serviceAPI';
 import colors from '../../constants/colors';
+import useScreenTopPadding from '../../hooks/useScreenTopPadding';
 import useFeedbackModal from '../../hooks/useFeedbackModal';
 
 export default function RegisterServiceScreen() {
+  const topPadding = useScreenTopPadding();
   const navigation = useNavigation();
   const { feedback, showFeedback, hideFeedback } = useFeedbackModal();
   const [formData, setFormData] = useState({
@@ -148,7 +150,7 @@ export default function RegisterServiceScreen() {
 
   return (
     <>
-      <ScrollView style={styles.container}>
+      <ScrollView style={[styles.container, { paddingTop: topPadding }]}>
         <View style={styles.formContainer}>
           <Text style={styles.title}>Cadastro de Serviço</Text>
 
@@ -227,7 +229,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#fff',
-    paddingTop: 50,
   },
   formContainer: {
     padding: 20,

--- a/src/screens/services/ServiceScreen.jsx
+++ b/src/screens/services/ServiceScreen.jsx
@@ -7,11 +7,13 @@ import FeedbackModal from '../../components/FeedbackModal';
 import HeaderAddButton from '../../components/HeaderAddButton';
 import SearchInput from '../../components/SearchInput';
 import colors from '../../constants/colors';
+import useScreenTopPadding from '../../hooks/useScreenTopPadding';
 import { Ionicons } from '@expo/vector-icons';
 import { isSessionExpiredError } from '../../services/sessionManager';
 import useFeedbackModal from '../../hooks/useFeedbackModal';
 
 const ServiceScreen = () => {
+  const topPadding = useScreenTopPadding();
   const navigation = useNavigation();
   const [services, setServices] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -147,7 +149,7 @@ const ServiceScreen = () => {
   );
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { paddingTop: topPadding }]}>
       <View style={styles.header}>
         <Text style={styles.title}>Serviços</Text>
         <HeaderAddButton
@@ -272,7 +274,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: colors.background,
-    paddingTop: 50,
   },
   header: {
     flexDirection: 'row',

--- a/src/screens/settings/SettingsScreen.jsx
+++ b/src/screens/settings/SettingsScreen.jsx
@@ -12,6 +12,7 @@ import Constants from 'expo-constants';
 import * as WebBrowser from 'expo-web-browser';
 import { Ionicons } from '@expo/vector-icons';
 import colors from '../../constants/colors';
+import useScreenTopPadding from '../../hooks/useScreenTopPadding';
 import {
   connectGoogleCalendar,
   disconnectGoogleCalendar,
@@ -29,6 +30,7 @@ const GOOGLE_CLIENT_ID = Constants.expoConfig?.extra?.googleOAuthClientId || '';
 const GOOGLE_REDIRECT_URI = 'com.bordd.beautyapp:/oauth/google';
 
 const SettingsScreen = () => {
+  const topPadding = useScreenTopPadding();
   const [calendarStatus, setCalendarStatus] = useState(null);
   const [loadingStatus, setLoadingStatus] = useState(true);
   const [connecting, setConnecting] = useState(false);
@@ -168,7 +170,7 @@ const SettingsScreen = () => {
   };
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { paddingTop: topPadding }]}>
       <Text style={styles.title}>Configurações</Text>
 
       <View style={styles.section}>
@@ -242,7 +244,6 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: colors.background,
     paddingHorizontal: 20,
-    paddingTop: 56,
   },
   title: {
     fontSize: 28,


### PR DESCRIPTION
Fecha #112.

## Causa

Nenhuma tela usava safe area no topo. O `SafeAreaProvider` está no `App.jsx`, mas só **fornece** os valores — ninguém aplicava. Sem `SafeAreaView`, com `headerShown: false` em todas as rotas, cada tela cravava um número mágico. E nem isso era consistente: `56` em Agenda/Financeiro/Configurações, `50` nas outras cinco.

O mesmo número produzia resultados completamente diferentes por plataforma:

| | Como o app desenha | `insets.top` | Efeito do `paddingTop: 56` |
|---|---|---|---|
| **Android** | status bar opaca, **fora** da viewport | `0` | 56px de vazio abaixo de uma barra que já estava fora → a "testa" |
| **iOS** | desenha **sob** o notch | 20–59 conforme o modelo | ≈ coincide com a área segura → parecia certo, por acidente |

Confirmei que o projeto **não** é edge-to-edge no Android: sem `react-native-edge-to-edge`, sem `android.edgeToEdgeEnabled`, e no Expo SDK 53 isso é opt-in. Por isso `insets.top` é `0` lá, e todo o espaçamento vinha do número fixo.

## Correção

Hook compartilhado `src/hooks/useScreenTopPadding.js`:

```js
Platform.OS === 'android'
  ? insets.top + SCREEN_TOP_GAP_ANDROID   // 16 — o respiro precisa vir de nós
  : Math.max(insets.top, SCREEN_TOP_BASE_IOS)   // 56 — o inset do notch já faz esse papel
```

As duas contas são diferentes porque a origem do layout é genuinamente diferente nas plataformas, não por conveniência.

| Aparelho | Antes | Depois |
|---|---|---|
| Android | 56 | **16** ✅ resolve a testa |
| iPhone 13/14 (inset 47) | 56 | 56 ✅ inalterado |
| iPhone SE (inset 20) | 56 | 56 ✅ inalterado |
| Dynamic Island (inset 59) | 56 | 59 — sai de dentro da ilha |

**O iOS foi preservado de propósito**, porque o relato foi explícito de que lá está normal. O único movimento é nos aparelhos com Dynamic Island, onde os 56 atuais ficam 3px *dentro* da ilha.

Bônus: se um dia o app virar edge-to-edge no Android, `insets.top` passa a valer e o cálculo se corrige sozinho, sem tocar em tela nenhuma.

## Escopo

`src/hooks/useScreenTopPadding.js` (novo) + 8 telas: Agenda, Financeiro, Configurações, Clientes, Cadastrar Cliente, Serviços, Cadastrar Serviço, Editar Serviço. Cinco linhas por tela; a conta vive num lugar só.

## Validação feita

- 43 testes seguem passando, sem regressão.
- Parse Babel nos 9 arquivos; `git diff --check` limpo; nenhum `paddingTop` fixo restante em `src/screens/`.

## Validação pendente

- [ ] **Android**: as 8 telas com o topo mais alto, sem colar na status bar
- [ ] **iOS**: as 8 telas **sem nenhuma mudança perceptível**
- [ ] Financeiro (é `contentContainerStyle` de `ScrollView`, não `style`) e as 3 telas de formulário em `ScrollView`
- [ ] Rotação e teclado aberto nas telas de formulário

## Nota de processo

Durante a implementação um script de edição em lote deixou um CR solto em `cliente.jsx` e `registerCustomer.jsx`, inflando o diff para ~1600 linhas de whitespace. Detectado, os dois arquivos foram restaurados e reeditados. O diff final é de **5 linhas por arquivo**, verificado com `git diff -w` e uma checagem de CR órfão.

## Versão

`1.4.4`. `app.json` preservado em `1.1.0`. Sem mudança de API.
